### PR TITLE
Limit string to 2kb, add tests for strings over 2kb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,4 @@ updatedeps:
 	go get -d -u ./...
 	go mod tidy -v
 	go mod vendor
+

--- a/Makefile
+++ b/Makefile
@@ -36,4 +36,3 @@ updatedeps:
 	go get -d -u ./...
 	go mod tidy -v
 	go mod vendor
-

--- a/example/models/animals/v1/schema_test.go
+++ b/example/models/animals/v1/schema_test.go
@@ -135,10 +135,6 @@ func TestSchemaPet(t *testing.T) {
 
 	result := sb.String()
 
-	if len(result) < 2000 {
-		t.Fatalf("Result less than 2000 bytes: result len %d", len(result))
-	}
-
 	insertMsg3 := &Pet{
 		TenantId:      "t1",
 		Id:            "obj4",

--- a/example/models/animals/v1/schema_test.go
+++ b/example/models/animals/v1/schema_test.go
@@ -130,7 +130,7 @@ func TestSchemaPet(t *testing.T) {
 
 	var sb strings.Builder
 	for i := 0; i < 2100; i++ {
-		sb.WriteString("ab")
+		sb.WriteString("a")
 	}
 
 	result := sb.String()

--- a/example/models/animals/v1/schema_test.go
+++ b/example/models/animals/v1/schema_test.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -126,6 +127,54 @@ func TestSchemaPet(t *testing.T) {
 	res, err := pg.DB.Exec(ctx, query, params...)
 	require.NoError(t, err, "query failed: %s\n\n%+v\n\n", query, params)
 	require.Equal(t, int64(1), res.RowsAffected())
+
+	var sb strings.Builder
+	for i := 0; i < 2100; i++ {
+		sb.WriteString("ab")
+	}
+
+	result := sb.String()
+
+	if len(result) < 2000 {
+		t.Fatalf("Result less than 2000 bytes: result len %d", len(result))
+	}
+
+	insertMsg3 := &Pet{
+		TenantId:      "t1",
+		Id:            "obj4",
+		CreatedAt:     timestamppb.Now(),
+		UpdatedAt:     timestamppb.Now(),
+		DisplayName:   result,
+		Description:   result,
+		SystemBuiltin: false,
+		Elapsed:       durationpb.New(time.Hour),
+		Profile:       &structpb.Struct{},
+		Cuteness:      1.0,
+		Price:         9000.0,
+		ExtraProfiles: []*structpb.Struct{
+			{
+				Fields: map[string]*structpb.Value{
+					"foo": {
+						Kind: &structpb.Value_BoolValue{
+							BoolValue: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	query, params, err = pgdb_v1.Insert(insertMsg3)
+	require.NoError(t, err)
+	_, err = pg.DB.Exec(ctx, query, params...)
+	require.NoError(t, err, "query failed: %s\n\n%+v\n\n", query, params)
+
+	query, params, err = pgdb_v1.Delete(insertMsg3)
+	require.NoError(t, err)
+	res, err = pg.DB.Exec(ctx, query, params...)
+	require.NoError(t, err, "query failed: %s\n\n%+v\n\n", query, params)
+	require.Equal(t, int64(1), res.RowsAffected())
+
 }
 
 func TestSchemaBook(t *testing.T) {

--- a/pgdb/v1/fts.go
+++ b/pgdb/v1/fts.go
@@ -22,9 +22,9 @@ type SearchContent struct {
 
 const (
 	minWordSize          = 3
-	KILO_BYTE            = 1000
-	lexemeMaxBytes       = KILO_BYTE * 2
-	tsvectorMaxMegabytes = KILO_BYTE * 1000
+	kiloByte             = 1000
+	lexemeMaxBytes       = kiloByte * 2
+	tsvectorMaxMegabytes = kiloByte * 1000
 )
 
 func interfaceToValue(in interface{}) string {

--- a/pgdb/v1/fts.go
+++ b/pgdb/v1/fts.go
@@ -22,8 +22,9 @@ type SearchContent struct {
 
 const (
 	minWordSize          = 3
-	lexemeMaxBytes       = 2000
-	tsvectorMaxMegabytes = 1000000
+	KILO_BYTE            = 1000
+	lexemeMaxBytes       = KILO_BYTE * 2
+	tsvectorMaxMegabytes = KILO_BYTE * 1000
 )
 
 func interfaceToValue(in interface{}) string {

--- a/pgdb/v1/fts.go
+++ b/pgdb/v1/fts.go
@@ -349,12 +349,7 @@ func FullTextSearchVectors(docs []*SearchContent, additionalFilters ...jargon.Fi
 
 	sb := strings.Builder{}
 	for _, v := range rv {
-		lexeme := pgLexeme(v.value, v.pos, v.weight)
-
-		if len(sb.String())+len(lexeme) >= maxBytes {
-			break
-		}
-		_, _ = sb.WriteString(lexeme)
+		_, _ = sb.WriteString(pgLexeme(v.value, v.pos, v.weight))
 		_, _ = sb.WriteString(" ")
 	}
 
@@ -410,7 +405,13 @@ func pgLexeme(value string, pos int, weight FieldOptions_FullTextWeight) string 
 	_, _ = sb.WriteString(":")
 	_, _ = sb.WriteString(strconv.FormatInt(int64(pos), 10))
 	_, _ = sb.WriteString(weightToString(weight))
-	return sb.String()
+
+	result := sb.String()
+	if len(result) > maxBytes {
+		return result[:maxBytes]
+	}
+
+	return result
 }
 
 func weightToString(weight FieldOptions_FullTextWeight) string {

--- a/pgdb/v1/fts.go
+++ b/pgdb/v1/fts.go
@@ -405,21 +405,27 @@ const specialReplaceChar = '�'
 
 func pgLexeme(value string, pos int, weight FieldOptions_FullTextWeight) string {
 	value = cleanToken(value)
+
+	p := strconv.FormatInt(int64(pos), 10)
+	w := weightToString(weight)
+
+	extraBytes := len(p) + len(w) + len("'") + len("'") + len(":")
+
+	// Tsvector must be less than 2kb
+	totalLength := len(value) + extraBytes
+	if totalLength > lexemeMaxBytes {
+		value = value[:lexemeMaxBytes-extraBytes]
+	}
+
 	sb := strings.Builder{}
 	_, _ = sb.WriteString("'")
 	_, _ = sb.WriteString(value)
 	_, _ = sb.WriteString("'")
 	_, _ = sb.WriteString(":")
-	_, _ = sb.WriteString(strconv.FormatInt(int64(pos), 10))
-	_, _ = sb.WriteString(weightToString(weight))
+	_, _ = sb.WriteString(p)
+	_, _ = sb.WriteString(w)
 
-	result := sb.String()
-	// Tsvector must be less than 2kb
-	if len(result) > lexemeMaxBytes {
-		return result[:lexemeMaxBytes]
-	}
-
-	return result
+	return sb.String()
 }
 
 func weightToString(weight FieldOptions_FullTextWeight) string {

--- a/pgdb/v1/fts.go
+++ b/pgdb/v1/fts.go
@@ -21,8 +21,8 @@ type SearchContent struct {
 }
 
 const (
-	maxBytes    = 2000
 	minWordSize = 3
+	maxBytes    = 2000
 )
 
 func interfaceToValue(in interface{}) string {
@@ -411,7 +411,7 @@ func pgLexeme(value string, pos int, weight FieldOptions_FullTextWeight) string 
 		return result[:maxBytes]
 	}
 
-	return result
+	return sb.String()
 }
 
 func weightToString(weight FieldOptions_FullTextWeight) string {

--- a/pgdb/v1/fts.go
+++ b/pgdb/v1/fts.go
@@ -359,7 +359,7 @@ func FullTextSearchVectors(docs []*SearchContent, additionalFilters ...jargon.Fi
 		_, _ = sb.WriteString(" ")
 	}
 
-	return exp.NewLiteralExpression("?::tsvector", sb)
+	return exp.NewLiteralExpression("?::tsvector", sb.String())
 }
 
 func FullTextSearchQuery(input string, additionalFilters ...jargon.Filter) exp.Expression {
@@ -413,11 +413,12 @@ func pgLexeme(value string, pos int, weight FieldOptions_FullTextWeight) string 
 	_, _ = sb.WriteString(weightToString(weight))
 
 	result := sb.String()
+	// Tsvector must be less than 2kb
 	if len(result) > lexemeMaxBytes {
 		return result[:lexemeMaxBytes]
 	}
 
-	return sb.String()
+	return result
 }
 
 func weightToString(weight FieldOptions_FullTextWeight) string {

--- a/pgdb/v1/fts.go
+++ b/pgdb/v1/fts.go
@@ -409,11 +409,13 @@ func pgLexeme(value string, pos int, weight FieldOptions_FullTextWeight) string 
 	p := strconv.FormatInt(int64(pos), 10)
 	w := weightToString(weight)
 
+	// Count the bytes to be added to format the lexeme
 	extraBytes := len(p) + len(w) + len("'") + len("'") + len(":")
 
 	// Tsvector must be less than 2kb
 	totalLength := len(value) + extraBytes
 	if totalLength > lexemeMaxBytes {
+		// Truncate the lexeme to fit in 2kb (minus the extra bytes which will be added later)
 		value = value[:lexemeMaxBytes-extraBytes]
 	}
 

--- a/pgdb/v1/fts.go
+++ b/pgdb/v1/fts.go
@@ -20,7 +20,10 @@ type SearchContent struct {
 	Value  interface{}
 }
 
-const minWordSize = 3
+const (
+	maxBytes    = 2000
+	minWordSize = 3
+)
 
 func interfaceToValue(in interface{}) string {
 	if in == nil {
@@ -346,7 +349,12 @@ func FullTextSearchVectors(docs []*SearchContent, additionalFilters ...jargon.Fi
 
 	sb := strings.Builder{}
 	for _, v := range rv {
-		_, _ = sb.WriteString(pgLexeme(v.value, v.pos, v.weight))
+		lexeme := pgLexeme(v.value, v.pos, v.weight)
+
+		if len(sb.String())+len(lexeme) >= maxBytes {
+			break
+		}
+		_, _ = sb.WriteString(lexeme)
 		_, _ = sb.WriteString(" ")
 	}
 

--- a/pgdb/v1/fts.go
+++ b/pgdb/v1/fts.go
@@ -352,7 +352,7 @@ func FullTextSearchVectors(docs []*SearchContent, additionalFilters ...jargon.Fi
 	sb := strings.Builder{}
 	for _, v := range rv {
 		// Tsvector must be less than 1 mb
-		if len(sb.String()) > tsvectorMaxMegabytes {
+		if sb.Len() > tsvectorMaxMegabytes {
 			break
 		}
 


### PR DESCRIPTION
Check bytes of strings.Builder{} as it updates, add a test case that attempts to upsert an object with a string larger than 2kb.

Running tool: /usr/local/go/bin/go test -timeout 30s -run ^TestSchemaPet$ github.com/ductone/protoc-gen-pgdb/example/models/animals/v1

=== RUN   TestSchemaPet
****  LEAVING ROOM FOR LEXEME FORMATTING:  bytes 1995
****  AFTER FORMATTING LEXME,                          : bytes 2000
--- PASS: TestSchemaPet (0.78s)
PASS
ok      github.com/ductone/protoc-gen-pgdb/example/models/animals/v1    0.789s




## Test
![Screenshot 2024-11-21 at 11 15 37 AM](https://github.com/user-attachments/assets/1a190189-1541-47ae-a5a4-a16f7862a284)
