### PR TITLE
collate ksuid columns using C

### DIFF
--- a/pgdb/v1/schema_sql.go
+++ b/pgdb/v1/schema_sql.go
@@ -147,3 +147,16 @@ func col2spec(col *Column) string {
 	}
 	return sbuf.String()
 }
+
+func ksuidColOverrideExpression(col *Column) string {
+	sbuf := &bytes.Buffer{}
+	_, _ = sbuf.WriteString(col.Type)
+	if !col.Nullable {
+		_, _ = sbuf.WriteString(" NOT NULL")
+	}
+	if col.Default != "" {
+		_, _ = sbuf.WriteString(" DEFAULT " + col.Default)
+	}
+	_, _ = sbuf.WriteString(" COLLATE \"C\"")
+	return sbuf.String()
+}


### PR DESCRIPTION
For tables partitioned by ksuid, set the collation to C during table creation.

Because we use a `CREATE IF NOT EXISTS` to create the table, existing tables (of which we have only one in prod) will not be affected by this change. Only newer ones will be