### PR TITLE
fix: resolve golangci-lint failures on main

### DIFF
--- a/internal/stackoverflow/generate/main.go
+++ b/internal/stackoverflow/generate/main.go
@@ -210,7 +210,7 @@ func fetchTags(page, pageSize int, site string) (wrapper, error) {
 	if err != nil {
 		return empty, err
 	}
-	r, httpErr := client.Do(req)
+	r, httpErr := client.Do(req) //nolint:gosec // URL is constructed from known constants, not user input.
 	if httpErr != nil {
 		return empty, httpErr
 	}

--- a/pgdb/v1/descriptor.go
+++ b/pgdb/v1/descriptor.go
@@ -8,7 +8,7 @@ import (
 // ColumnSourceKind indicates the origin/nature of a column.
 type ColumnSourceKind int32
 
-//nolint:revive,stylecheck // Using underscore naming to match proto enum style.
+//nolint:revive // Using underscore naming to match proto enum style.
 const (
 	// ColumnSourceKind_PROTO_FIELD is a direct mapping to a single proto field.
 	// ProtoFieldPath and ProtoPath are populated.


### PR DESCRIPTION
## Summary
- Suppress `gosec` G704 (SSRF) false positive in `internal/stackoverflow/generate/main.go` — the URL is constructed from known constants, not user input
- Remove unknown `stylecheck` linter from `//nolint` directive in `pgdb/v1/descriptor.go` (not an enabled linter, causing `nolintlint` warning)

## Test plan
- [ ] Verify `golangci-lint run` passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)