### PR TITLE
feat: batch catalog reads for schema migration planning

### DIFF
--- a/pgdb/v1/schema_bulk.go
+++ b/pgdb/v1/schema_bulk.go
@@ -169,15 +169,15 @@ func (s *CatalogSnapshot) readAllStorageParams(ctx context.Context, db sqlScanne
 		if reloptions == nil {
 			continue
 		}
-		params := make(map[string]string)
+		sp := make(map[string]string)
 		for _, opt := range reloptions {
 			parts := strings.SplitN(opt, "=", 2)
 			if len(parts) == 2 {
-				params[parts[0]] = parts[1]
+				sp[parts[0]] = parts[1]
 			}
 		}
-		if len(params) > 0 {
-			s.storageParams[tableName] = params
+		if len(sp) > 0 {
+			s.storageParams[tableName] = sp
 		}
 	}
 	return rows.Err()

--- a/pgdb/v1/schema_bulk.go
+++ b/pgdb/v1/schema_bulk.go
@@ -148,6 +148,7 @@ func (s *CatalogSnapshot) readAllStorageParams(ctx context.Context, db sqlScanne
 	qb = qb.Select("pg_class.relname", "pg_class.reloptions")
 	qb = qb.Join(goqu.T("pg_namespace"), goqu.On(goqu.I("pg_namespace.oid").Eq(goqu.I("pg_class.relnamespace"))))
 	qb = qb.Where(goqu.L("pg_namespace.nspname = ?", "public"))
+	qb = qb.Where(goqu.L("pg_class.relkind IN (?, ?)", "r", "p"))
 	qb = qb.Where(goqu.L("pg_class.reloptions IS NOT NULL"))
 	query, params, err := qb.ToSQL()
 	if err != nil {
@@ -188,34 +189,29 @@ func (s *CatalogSnapshot) columnsForTable(tableName string) map[string]struct{} 
 	return s.columns[tableName]
 }
 
-// indexesForTable returns the indexes for a table, or an empty map if none exist.
+// indexesForTable returns the indexes for a table, or nil if none exist.
+// Nil maps are safe for len() checks and lookups in Go.
 func (s *CatalogSnapshot) indexesForTable(tableName string) map[string]struct{} {
-	if m := s.indexes[tableName]; m != nil {
-		return m
-	}
-	return make(map[string]struct{})
+	return s.indexes[tableName]
 }
 
-// statsForTable returns the statistics for a table, or an empty map if none exist.
+// statsForTable returns the statistics for a table, or nil if none exist.
 func (s *CatalogSnapshot) statsForTable(tableName string) map[string]struct{} {
-	if m := s.stats[tableName]; m != nil {
-		return m
-	}
-	return make(map[string]struct{})
+	return s.stats[tableName]
 }
 
-// storageParamsForTable returns storage parameters for a table, or an empty map if none exist.
+// storageParamsForTable returns storage parameters for a table, or nil if none exist.
 func (s *CatalogSnapshot) storageParamsForTable(tableName string) map[string]string {
-	if m := s.storageParams[tableName]; m != nil {
-		return m
-	}
-	return make(map[string]string)
+	return s.storageParams[tableName]
 }
 
 // MigrationsWithCatalog computes the DDL migrations needed for a single table using
 // a pre-fetched CatalogSnapshot instead of querying the catalog per table.
 // This is functionally identical to Migrations but avoids per-table catalog queries.
 func MigrationsWithCatalog(snap *CatalogSnapshot, msg DBReflectMessage, dialect Dialect) ([]string, error) {
+	if snap == nil {
+		return nil, fmt.Errorf("nil CatalogSnapshot")
+	}
 	rv := make([]string, 0)
 	dbr := msg.DBReflect(dialect)
 	desc := dbr.Descriptor()

--- a/pgdb/v1/schema_bulk.go
+++ b/pgdb/v1/schema_bulk.go
@@ -1,0 +1,285 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/doug-martin/goqu/v9"
+)
+
+// CatalogSnapshot holds pre-fetched catalog metadata for all tables,
+// eliminating the need for per-table catalog queries during migration planning.
+type CatalogSnapshot struct {
+	// columns maps table_name -> set of column names
+	columns map[string]map[string]struct{}
+	// indexes maps table_name -> set of index names
+	indexes map[string]map[string]struct{}
+	// stats maps table_name -> set of statistic names
+	stats map[string]map[string]struct{}
+	// storageParams maps table_name -> storage parameter key-value pairs
+	storageParams map[string]map[string]string
+}
+
+// ReadCatalogSnapshot fetches columns, indexes, statistics, and storage parameters
+// for all tables in the public schema in 4 bulk queries, rather than 4 queries per table.
+func ReadCatalogSnapshot(ctx context.Context, db sqlScanner) (*CatalogSnapshot, error) {
+	snap := &CatalogSnapshot{
+		columns:       make(map[string]map[string]struct{}),
+		indexes:       make(map[string]map[string]struct{}),
+		stats:         make(map[string]map[string]struct{}),
+		storageParams: make(map[string]map[string]string),
+	}
+
+	if err := snap.readAllColumns(ctx, db); err != nil {
+		return nil, fmt.Errorf("catalog snapshot: reading columns: %w", err)
+	}
+	if err := snap.readAllIndexes(ctx, db); err != nil {
+		return nil, fmt.Errorf("catalog snapshot: reading indexes: %w", err)
+	}
+	if err := snap.readAllStats(ctx, db); err != nil {
+		return nil, fmt.Errorf("catalog snapshot: reading stats: %w", err)
+	}
+	if err := snap.readAllStorageParams(ctx, db); err != nil {
+		return nil, fmt.Errorf("catalog snapshot: reading storage params: %w", err)
+	}
+
+	return snap, nil
+}
+
+func (s *CatalogSnapshot) readAllColumns(ctx context.Context, db sqlScanner) error {
+	// Use pg_attribute + pg_class + pg_namespace instead of information_schema.columns
+	// for significantly better performance. information_schema.columns is a complex view
+	// that joins many catalog tables; querying pg_attribute directly is much faster.
+	query := `SELECT c.relname, a.attname
+FROM pg_attribute a
+JOIN pg_class c ON c.oid = a.attrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public'
+  AND a.attnum > 0
+  AND NOT a.attisdropped
+  AND c.relkind IN ('r', 'p')
+ORDER BY c.relname`
+
+	rows, err := db.Query(ctx, query)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var tableName, columnName string
+		if err := rows.Scan(&tableName, &columnName); err != nil {
+			return err
+		}
+		if s.columns[tableName] == nil {
+			s.columns[tableName] = make(map[string]struct{})
+		}
+		s.columns[tableName][columnName] = struct{}{}
+	}
+	return rows.Err()
+}
+
+func (s *CatalogSnapshot) readAllIndexes(ctx context.Context, db sqlScanner) error {
+	// Query pg_index + pg_class directly instead of pg_indexes view.
+	query := `SELECT ct.relname, ci.relname
+FROM pg_index i
+JOIN pg_class ct ON ct.oid = i.indrelid
+JOIN pg_class ci ON ci.oid = i.indexrelid
+JOIN pg_namespace n ON n.oid = ct.relnamespace
+WHERE n.nspname = 'public'
+ORDER BY ct.relname`
+
+	rows, err := db.Query(ctx, query)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var tableName, indexName string
+		if err := rows.Scan(&tableName, &indexName); err != nil {
+			return err
+		}
+		if s.indexes[tableName] == nil {
+			s.indexes[tableName] = make(map[string]struct{})
+		}
+		s.indexes[tableName][indexName] = struct{}{}
+	}
+	return rows.Err()
+}
+
+func (s *CatalogSnapshot) readAllStats(ctx context.Context, db sqlScanner) error {
+	dialect := goqu.Dialect("postgres")
+
+	qb := dialect.From("pg_statistic_ext")
+	qb = qb.Select("pg_class.relname", "pg_statistic_ext.stxname")
+	qb = qb.Join(goqu.T("pg_class"), goqu.On(goqu.I("pg_class.oid").Eq(goqu.I("pg_statistic_ext.stxrelid"))))
+	qb = qb.Join(goqu.T("pg_namespace"), goqu.On(goqu.I("pg_namespace.oid").Eq(goqu.I("pg_class.relnamespace"))))
+	qb = qb.Where(goqu.L("pg_namespace.nspname = ?", "public"))
+	query, params, err := qb.ToSQL()
+	if err != nil {
+		return err
+	}
+
+	rows, err := db.Query(ctx, query, params...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var tableName, stName string
+		if err := rows.Scan(&tableName, &stName); err != nil {
+			return err
+		}
+		if s.stats[tableName] == nil {
+			s.stats[tableName] = make(map[string]struct{})
+		}
+		s.stats[tableName][stName] = struct{}{}
+	}
+	return rows.Err()
+}
+
+func (s *CatalogSnapshot) readAllStorageParams(ctx context.Context, db sqlScanner) error {
+	dialect := goqu.Dialect("postgres")
+
+	qb := dialect.From("pg_class")
+	qb = qb.Select("pg_class.relname", "pg_class.reloptions")
+	qb = qb.Join(goqu.T("pg_namespace"), goqu.On(goqu.I("pg_namespace.oid").Eq(goqu.I("pg_class.relnamespace"))))
+	qb = qb.Where(goqu.L("pg_namespace.nspname = ?", "public"))
+	qb = qb.Where(goqu.L("pg_class.reloptions IS NOT NULL"))
+	query, params, err := qb.ToSQL()
+	if err != nil {
+		return err
+	}
+
+	rows, err := db.Query(ctx, query, params...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var tableName string
+		var reloptions []string
+		if err := rows.Scan(&tableName, &reloptions); err != nil {
+			return err
+		}
+		if reloptions == nil {
+			continue
+		}
+		params := make(map[string]string)
+		for _, opt := range reloptions {
+			parts := strings.SplitN(opt, "=", 2)
+			if len(parts) == 2 {
+				params[parts[0]] = parts[1]
+			}
+		}
+		if len(params) > 0 {
+			s.storageParams[tableName] = params
+		}
+	}
+	return rows.Err()
+}
+
+// columnsForTable returns the columns for a table, or nil if the table doesn't exist.
+func (s *CatalogSnapshot) columnsForTable(tableName string) map[string]struct{} {
+	return s.columns[tableName]
+}
+
+// indexesForTable returns the indexes for a table, or an empty map if none exist.
+func (s *CatalogSnapshot) indexesForTable(tableName string) map[string]struct{} {
+	if m := s.indexes[tableName]; m != nil {
+		return m
+	}
+	return make(map[string]struct{})
+}
+
+// statsForTable returns the statistics for a table, or an empty map if none exist.
+func (s *CatalogSnapshot) statsForTable(tableName string) map[string]struct{} {
+	if m := s.stats[tableName]; m != nil {
+		return m
+	}
+	return make(map[string]struct{})
+}
+
+// storageParamsForTable returns storage parameters for a table, or an empty map if none exist.
+func (s *CatalogSnapshot) storageParamsForTable(tableName string) map[string]string {
+	if m := s.storageParams[tableName]; m != nil {
+		return m
+	}
+	return make(map[string]string)
+}
+
+// MigrationsWithCatalog computes the DDL migrations needed for a single table using
+// a pre-fetched CatalogSnapshot instead of querying the catalog per table.
+// This is functionally identical to Migrations but avoids per-table catalog queries.
+func MigrationsWithCatalog(snap *CatalogSnapshot, msg DBReflectMessage, dialect Dialect) ([]string, error) {
+	rv := make([]string, 0)
+	dbr := msg.DBReflect(dialect)
+	desc := dbr.Descriptor()
+
+	haveCols := snap.columnsForTable(desc.TableName())
+
+	if len(haveCols) == 0 {
+		return CreateSchema(msg, dialect)
+	}
+
+	for _, field := range desc.Fields() {
+		if _, ok := haveCols[field.Name]; ok {
+			continue
+		}
+		query := col2alter(desc, field)
+		rv = append(rv, query)
+	}
+
+	indexes := snap.indexesForTable(desc.TableName())
+
+	for _, idx := range desc.Indexes() {
+		if idx.IsPrimary {
+			continue
+		}
+
+		_, exists := indexes[idx.Name]
+		query := index2sql(desc, idx)
+
+		if idx.IsDropped {
+			if exists {
+				rv = append(rv, query)
+			}
+			continue
+		}
+
+		if !exists {
+			rv = append(rv, query)
+			continue
+		}
+	}
+
+	existingStats := snap.statsForTable(desc.TableName())
+
+	for _, st := range desc.Statistics() {
+		_, exists := existingStats[st.Name]
+		query := statistics2sql(desc, st)
+
+		if st.IsDropped {
+			if exists {
+				rv = append(rv, query)
+			}
+			continue
+		}
+
+		if !exists {
+			rv = append(rv, query)
+			continue
+		}
+	}
+
+	existingStorageParams := snap.storageParamsForTable(desc.TableName())
+	if storageParamsAlter := storageParams2alter(desc, existingStorageParams); storageParamsAlter != "" {
+		rv = append(rv, storageParamsAlter)
+	}
+
+	return rv, nil
+}

--- a/pgdb/v1/schema_bulk_test.go
+++ b/pgdb/v1/schema_bulk_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestMigrationsWithCatalog_NewTable(t *testing.T) {
+func TestCatalogSnapshot_ColumnsForTable_Missing(t *testing.T) {
 	snap := &CatalogSnapshot{
 		columns:       make(map[string]map[string]struct{}),
 		indexes:       make(map[string]map[string]struct{}),
@@ -12,14 +12,17 @@ func TestMigrationsWithCatalog_NewTable(t *testing.T) {
 		storageParams: make(map[string]map[string]string),
 	}
 
-	// Table doesn't exist in snapshot → should return CreateSchema output
 	cols := snap.columnsForTable("nonexistent_table")
+	if cols != nil {
+		t.Errorf("expected nil for nonexistent table, got %v", cols)
+	}
+	// len(nil map) == 0, which triggers CreateSchema path in MigrationsWithCatalog
 	if len(cols) != 0 {
-		t.Errorf("expected empty columns for nonexistent table, got %d", len(cols))
+		t.Errorf("expected len 0 for nil columns, got %d", len(cols))
 	}
 }
 
-func TestMigrationsWithCatalog_ExistingTable(t *testing.T) {
+func TestCatalogSnapshot_Accessors(t *testing.T) {
 	snap := &CatalogSnapshot{
 		columns: map[string]map[string]struct{}{
 			"test_table": {
@@ -46,13 +49,15 @@ func TestMigrationsWithCatalog_ExistingTable(t *testing.T) {
 		t.Errorf("expected 1 index, got %d", len(indexes))
 	}
 
-	// Non-existent table should return empty maps (not nil)
-	indexes2 := snap.indexesForTable("other_table")
-	if indexes2 == nil {
-		t.Error("expected non-nil map for missing table indexes")
+	// Missing tables return nil (safe for len and lookups)
+	if snap.indexesForTable("other") != nil {
+		t.Error("expected nil for missing table indexes")
 	}
-	if len(indexes2) != 0 {
-		t.Errorf("expected 0 indexes for missing table, got %d", len(indexes2))
+	if snap.statsForTable("other") != nil {
+		t.Error("expected nil for missing table stats")
+	}
+	if snap.storageParamsForTable("other") != nil {
+		t.Error("expected nil for missing table storage params")
 	}
 }
 
@@ -76,13 +81,11 @@ func TestCatalogSnapshot_StorageParams(t *testing.T) {
 	if params["fillfactor"] != "80" {
 		t.Errorf("expected fillfactor=80, got %s", params["fillfactor"])
 	}
+}
 
-	// Non-existent table
-	params2 := snap.storageParamsForTable("other_table")
-	if params2 == nil {
-		t.Error("expected non-nil map for missing table storage params")
-	}
-	if len(params2) != 0 {
-		t.Errorf("expected 0 params for missing table, got %d", len(params2))
+func TestMigrationsWithCatalog_NilSnapshot(t *testing.T) {
+	_, err := MigrationsWithCatalog(nil, nil, 0)
+	if err == nil {
+		t.Error("expected error for nil snapshot")
 	}
 }

--- a/pgdb/v1/schema_bulk_test.go
+++ b/pgdb/v1/schema_bulk_test.go
@@ -1,0 +1,88 @@
+package v1
+
+import (
+	"testing"
+)
+
+func TestMigrationsWithCatalog_NewTable(t *testing.T) {
+	snap := &CatalogSnapshot{
+		columns:       make(map[string]map[string]struct{}),
+		indexes:       make(map[string]map[string]struct{}),
+		stats:         make(map[string]map[string]struct{}),
+		storageParams: make(map[string]map[string]string),
+	}
+
+	// Table doesn't exist in snapshot → should return CreateSchema output
+	cols := snap.columnsForTable("nonexistent_table")
+	if len(cols) != 0 {
+		t.Errorf("expected empty columns for nonexistent table, got %d", len(cols))
+	}
+}
+
+func TestMigrationsWithCatalog_ExistingTable(t *testing.T) {
+	snap := &CatalogSnapshot{
+		columns: map[string]map[string]struct{}{
+			"test_table": {
+				"col1": {},
+				"col2": {},
+			},
+		},
+		indexes: map[string]map[string]struct{}{
+			"test_table": {
+				"idx1": {},
+			},
+		},
+		stats:         make(map[string]map[string]struct{}),
+		storageParams: make(map[string]map[string]string),
+	}
+
+	cols := snap.columnsForTable("test_table")
+	if len(cols) != 2 {
+		t.Errorf("expected 2 columns, got %d", len(cols))
+	}
+
+	indexes := snap.indexesForTable("test_table")
+	if len(indexes) != 1 {
+		t.Errorf("expected 1 index, got %d", len(indexes))
+	}
+
+	// Non-existent table should return empty maps (not nil)
+	indexes2 := snap.indexesForTable("other_table")
+	if indexes2 == nil {
+		t.Error("expected non-nil map for missing table indexes")
+	}
+	if len(indexes2) != 0 {
+		t.Errorf("expected 0 indexes for missing table, got %d", len(indexes2))
+	}
+}
+
+func TestCatalogSnapshot_StorageParams(t *testing.T) {
+	snap := &CatalogSnapshot{
+		columns: make(map[string]map[string]struct{}),
+		indexes: make(map[string]map[string]struct{}),
+		stats:   make(map[string]map[string]struct{}),
+		storageParams: map[string]map[string]string{
+			"test_table": {
+				"fillfactor":                  "80",
+				"autovacuum_vacuum_threshold": "10000",
+			},
+		},
+	}
+
+	params := snap.storageParamsForTable("test_table")
+	if len(params) != 2 {
+		t.Errorf("expected 2 storage params, got %d", len(params))
+	}
+	if params["fillfactor"] != "80" {
+		t.Errorf("expected fillfactor=80, got %s", params["fillfactor"])
+	}
+
+	// Non-existent table
+	params2 := snap.storageParamsForTable("other_table")
+	if params2 == nil {
+		t.Error("expected non-nil map for missing table storage params")
+	}
+	if len(params2) != 0 {
+		t.Errorf("expected 0 params for missing table, got %d", len(params2))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `CatalogSnapshot` type that pre-fetches all catalog metadata (columns, indexes, statistics, storage params) in **4 bulk queries** instead of 4 queries per table
- Adds `MigrationsWithCatalog()` that uses the snapshot for migration planning, functionally identical to `Migrations()`
- Switches from slow `information_schema.columns` view to direct `pg_attribute` queries
- Existing `Migrations()` API preserved for backward compatibility

## Problem

With 200+ models, `EnsureSchema` runs ~800 sequential catalog queries (4 per table). On a loaded Aurora PG17 instance these take 20-30 minutes total — the dominant cost of schema migration, even when most tables have zero actual DDL to run.

## Caller migration

Callers switch from:
```go
for _, model := range models {
    lines, _ := pgdb_v1.Migrations(ctx, conn, model, dialect)
    // execute lines...
}
```

To:
```go
snap, _ := pgdb_v1.ReadCatalogSnapshot(ctx, conn)
for _, model := range models {
    lines, _ := pgdb_v1.MigrationsWithCatalog(snap, model, dialect)
    // execute lines...
}
```

## Safety audit

| Concern | Status |
|---|---|
| Logic parity with `Migrations()` | `MigrationsWithCatalog` is line-for-line identical logic, reads from snapshot instead of DB |
| New table detection (`len(haveCols) == 0`) | Works — `nil` map from snapshot has `len() == 0` in Go, same as original empty map |
| Schema filtering | **Improvement** — bulk queries all filter on `public` schema. Original `readColumns` and `readIndexes` didn't filter schema |
| `IF NOT EXISTS` / `IF EXISTS` safety | All DDL uses these clauses, so stale snapshot can't cause duplicate creation errors |
| `rows.Err()` checking | **Improvement** — bulk queries check it, original doesn't |
| Backward compatibility | `Migrations()` untouched, new API is additive only |

## Test plan

- [x] Existing unit tests pass
- [x] New unit tests for CatalogSnapshot accessors
- [ ] Integration test with real PG (covered by existing example/models tests in CI)
- [ ] Validate in c1 repo after vendoring update

🤖 Generated with [Claude Code](https://claude.com/claude-code)