### PR TITLE
fix(lint): collapse fts dotSplitTerms loop (S1011)

### DIFF
--- a/pgdb/v1/fts.go
+++ b/pgdb/v1/fts.go
@@ -423,9 +423,7 @@ func FullTextSearchQuery(input string, additionalFilters ...jargon.Filter) exp.E
 			return -1
 		}, raw)
 
-		for _, part := range strings.Fields(ds) {
-			dotSplitTerms = append(dotSplitTerms, part)
-		}
+		dotSplitTerms = append(dotSplitTerms, strings.Fields(ds)...)
 	}
 
 	origQuery := buildSearchQuery(searchTerms)


### PR DESCRIPTION
## Summary

Resolves the staticcheck `S1011` failure introduced by #139 (`cf492ec`) in `pgdb/v1/fts.go:426`. CI lint is currently red on `main` and on every open PR rebased onto it.

The fix is the exact replacement staticcheck suggests: replace the trivial loop appending each element with `append(slice, strings.Fields(ds)...)`. Behavior is identical.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] CI lint passes once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)