### PR TITLE
feat: add cheap Message.PKSK() key helper

### DIFF
--- a/example/models/animals/v1/animals.pb.pgdb.go
+++ b/example/models/animals/v1/animals.pb.pgdb.go
@@ -970,6 +970,31 @@ func (m *pgdbMessagePet) SearchData(opts ...pgdb_v1.RecordOptionsFunc) []*pgdb_v
 func (m *pgdbMessagePet) Dialect() pgdb_v1.Dialect {
 	return pgdb_v1.DialectOrDefault(m.dialect)
 }
+func (m *pgdbMessagePet) PKSK() string {
+	var sb strings.Builder
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("models_animals_v1_pet")
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetTenantId())
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetId())
+
+	cfv2 := sb.String()
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("example")
+
+	cfv3 := sb.String()
+
+	return cfv2 + "|" + cfv3
+}
 
 type PetDB struct {
 	tableName string
@@ -3259,6 +3284,27 @@ func (m *pgdbMessageScalarValue) SearchData(opts ...pgdb_v1.RecordOptionsFunc) [
 
 func (m *pgdbMessageScalarValue) Dialect() pgdb_v1.Dialect {
 	return pgdb_v1.DialectOrDefault(m.dialect)
+}
+func (m *pgdbMessageScalarValue) PKSK() string {
+	var sb strings.Builder
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("models_animals_v1_scalar_value")
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetTenantId())
+
+	cfv2 := sb.String()
+
+	sb.Reset()
+
+	_, _ = sb.WriteString(m.self.GetId())
+
+	cfv3 := sb.String()
+
+	return cfv2 + "|" + cfv3
 }
 
 type ScalarValueDB struct {
@@ -5625,6 +5671,31 @@ func (m *pgdbMessageBook) SearchData(opts ...pgdb_v1.RecordOptionsFunc) []*pgdb_
 func (m *pgdbMessageBook) Dialect() pgdb_v1.Dialect {
 	return pgdb_v1.DialectOrDefault(m.dialect)
 }
+func (m *pgdbMessageBook) PKSK() string {
+	var sb strings.Builder
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("models_animals_v1_book")
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetTenantId())
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetId())
+
+	cfv2 := sb.String()
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("example")
+
+	cfv3 := sb.String()
+
+	return cfv2 + "|" + cfv3
+}
 
 type BookDB struct {
 	tableName string
@@ -7038,6 +7109,27 @@ func (m *pgdbMessageNewspaper) SearchData(opts ...pgdb_v1.RecordOptionsFunc) []*
 
 func (m *pgdbMessageNewspaper) Dialect() pgdb_v1.Dialect {
 	return pgdb_v1.DialectOrDefault(m.dialect)
+}
+func (m *pgdbMessageNewspaper) PKSK() string {
+	var sb strings.Builder
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("models_animals_v1_newspaper")
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetId())
+
+	cfv2 := sb.String()
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("example")
+
+	cfv3 := sb.String()
+
+	return cfv2 + "|" + cfv3
 }
 
 type NewspaperDB struct {

--- a/example/models/city/v1/city.pb.pgdb.go
+++ b/example/models/city/v1/city.pb.pgdb.go
@@ -842,6 +842,31 @@ func (m *pgdbMessageAttractions) SearchData(opts ...pgdb_v1.RecordOptionsFunc) [
 func (m *pgdbMessageAttractions) Dialect() pgdb_v1.Dialect {
 	return pgdb_v1.DialectOrDefault(m.dialect)
 }
+func (m *pgdbMessageAttractions) PKSK() string {
+	var sb strings.Builder
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("models_city_v1_attractions")
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetTenantId())
+
+	cfv2 := sb.String()
+
+	sb.Reset()
+
+	_, _ = sb.WriteString(m.self.GetId())
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(strconv.FormatInt(int64(m.self.GetNumid()), 10))
+
+	cfv3 := sb.String()
+
+	return cfv2 + "|" + cfv3
+}
 
 type AttractionsDB struct {
 	tableName string
@@ -10233,6 +10258,27 @@ func (m *pgdbMessageAttractionsV2) SearchData(opts ...pgdb_v1.RecordOptionsFunc)
 func (m *pgdbMessageAttractionsV2) Dialect() pgdb_v1.Dialect {
 	return pgdb_v1.DialectOrDefault(m.dialect)
 }
+func (m *pgdbMessageAttractionsV2) PKSK() string {
+	var sb strings.Builder
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("models_city_v1_attractions_v_2")
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetTenantId())
+
+	cfv2 := sb.String()
+
+	sb.Reset()
+
+	_, _ = sb.WriteString(m.self.GetId())
+
+	cfv3 := sb.String()
+
+	return cfv2 + "|" + cfv3
+}
 
 type AttractionsV2DB struct {
 	tableName string
@@ -11717,6 +11763,27 @@ func (m *pgdbMessageNestedOnlyMiddle) SearchData(opts ...pgdb_v1.RecordOptionsFu
 func (m *pgdbMessageNestedOnlyMiddle) Dialect() pgdb_v1.Dialect {
 	return pgdb_v1.DialectOrDefault(m.dialect)
 }
+func (m *pgdbMessageNestedOnlyMiddle) PKSK() string {
+	var sb strings.Builder
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("models_city_v1_nested_only_middle")
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetTenantId())
+
+	cfv2 := sb.String()
+
+	sb.Reset()
+
+	_, _ = sb.WriteString(m.self.GetId())
+
+	cfv3 := sb.String()
+
+	return cfv2 + "|" + cfv3
+}
 
 type NestedOnlyMiddleDB struct {
 	tableName string
@@ -13054,6 +13121,27 @@ func (m *pgdbMessageNestedOnlyWrapper) SearchData(opts ...pgdb_v1.RecordOptionsF
 
 func (m *pgdbMessageNestedOnlyWrapper) Dialect() pgdb_v1.Dialect {
 	return pgdb_v1.DialectOrDefault(m.dialect)
+}
+func (m *pgdbMessageNestedOnlyWrapper) PKSK() string {
+	var sb strings.Builder
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("models_city_v1_nested_only_wrapper")
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetTenantId())
+
+	cfv2 := sb.String()
+
+	sb.Reset()
+
+	_, _ = sb.WriteString(m.self.GetId())
+
+	cfv3 := sb.String()
+
+	return cfv2 + "|" + cfv3
 }
 
 type NestedOnlyWrapperDB struct {
@@ -15024,6 +15112,27 @@ func (m *pgdbMessageDuplicateTypeBugOuter) SearchData(opts ...pgdb_v1.RecordOpti
 func (m *pgdbMessageDuplicateTypeBugOuter) Dialect() pgdb_v1.Dialect {
 	return pgdb_v1.DialectOrDefault(m.dialect)
 }
+func (m *pgdbMessageDuplicateTypeBugOuter) PKSK() string {
+	var sb strings.Builder
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("models_city_v1_duplicate_type_bug_outer")
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetTenantId())
+
+	cfv2 := sb.String()
+
+	sb.Reset()
+
+	_, _ = sb.WriteString(m.self.GetId())
+
+	cfv3 := sb.String()
+
+	return cfv2 + "|" + cfv3
+}
 
 type DuplicateTypeBugOuterDB struct {
 	tableName string
@@ -16540,6 +16649,27 @@ func (m *pgdbMessageEmbeddedWithOwnDB) SearchData(opts ...pgdb_v1.RecordOptionsF
 func (m *pgdbMessageEmbeddedWithOwnDB) Dialect() pgdb_v1.Dialect {
 	return pgdb_v1.DialectOrDefault(m.dialect)
 }
+func (m *pgdbMessageEmbeddedWithOwnDB) PKSK() string {
+	var sb strings.Builder
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("models_city_v1_embedded_with_own_db")
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetTenantId())
+
+	cfv2 := sb.String()
+
+	sb.Reset()
+
+	_, _ = sb.WriteString(m.self.GetId())
+
+	cfv3 := sb.String()
+
+	return cfv2 + "|" + cfv3
+}
 
 type EmbeddedWithOwnDBDB struct {
 	tableName string
@@ -17725,6 +17855,27 @@ func (m *pgdbMessageParentWithEmbeddedDB) SearchData(opts ...pgdb_v1.RecordOptio
 
 func (m *pgdbMessageParentWithEmbeddedDB) Dialect() pgdb_v1.Dialect {
 	return pgdb_v1.DialectOrDefault(m.dialect)
+}
+func (m *pgdbMessageParentWithEmbeddedDB) PKSK() string {
+	var sb strings.Builder
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("models_city_v1_parent_with_embedded_db")
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetTenantId())
+
+	cfv2 := sb.String()
+
+	sb.Reset()
+
+	_, _ = sb.WriteString(m.self.GetId())
+
+	cfv3 := sb.String()
+
+	return cfv2 + "|" + cfv3
 }
 
 type ParentWithEmbeddedDBDB struct {
@@ -19542,6 +19693,27 @@ func (m *pgdbMessageDuplicateMethodsBugRoot) SearchData(opts ...pgdb_v1.RecordOp
 
 func (m *pgdbMessageDuplicateMethodsBugRoot) Dialect() pgdb_v1.Dialect {
 	return pgdb_v1.DialectOrDefault(m.dialect)
+}
+func (m *pgdbMessageDuplicateMethodsBugRoot) PKSK() string {
+	var sb strings.Builder
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("models_city_v1_duplicate_methods_bug_root")
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetTenantId())
+
+	cfv2 := sb.String()
+
+	sb.Reset()
+
+	_, _ = sb.WriteString(m.self.GetId())
+
+	cfv3 := sb.String()
+
+	return cfv2 + "|" + cfv3
 }
 
 type DuplicateMethodsBugRootDB struct {
@@ -21470,6 +21642,27 @@ func (m *pgdbMessageDuplicateTypePathsBugRoot) SearchData(opts ...pgdb_v1.Record
 
 func (m *pgdbMessageDuplicateTypePathsBugRoot) Dialect() pgdb_v1.Dialect {
 	return pgdb_v1.DialectOrDefault(m.dialect)
+}
+func (m *pgdbMessageDuplicateTypePathsBugRoot) PKSK() string {
+	var sb strings.Builder
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("models_city_v1_duplicate_type_paths_bug_root")
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetTenantId())
+
+	cfv2 := sb.String()
+
+	sb.Reset()
+
+	_, _ = sb.WriteString(m.self.GetId())
+
+	cfv3 := sb.String()
+
+	return cfv2 + "|" + cfv3
 }
 
 type DuplicateTypePathsBugRootDB struct {

--- a/example/models/food/v1/food.pb.pgdb.go
+++ b/example/models/food/v1/food.pb.pgdb.go
@@ -661,6 +661,31 @@ func (m *pgdbMessagePasta) SearchData(opts ...pgdb_v1.RecordOptionsFunc) []*pgdb
 func (m *pgdbMessagePasta) Dialect() pgdb_v1.Dialect {
 	return pgdb_v1.DialectOrDefault(m.dialect)
 }
+func (m *pgdbMessagePasta) PKSK() string {
+	var sb strings.Builder
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("models_food_v1_pasta")
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetTenantId())
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetId())
+
+	cfv2 := sb.String()
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("example")
+
+	cfv3 := sb.String()
+
+	return cfv2 + "|" + cfv3
+}
 
 type PastaDB struct {
 	tableName string
@@ -2163,6 +2188,39 @@ func (m *pgdbMessagePastaIngredient) SearchData(opts ...pgdb_v1.RecordOptionsFun
 
 func (m *pgdbMessagePastaIngredient) Dialect() pgdb_v1.Dialect {
 	return pgdb_v1.DialectOrDefault(m.dialect)
+}
+func (m *pgdbMessagePastaIngredient) PKSK() string {
+	var sb strings.Builder
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("models_food_v1_pasta_ingredient")
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetTenantId())
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetPastaId())
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetIngredientId())
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetId())
+
+	cfv2 := sb.String()
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("exampleingredient")
+
+	cfv3 := sb.String()
+
+	return cfv2 + "|" + cfv3
 }
 
 type PastaIngredientDB struct {
@@ -3717,6 +3775,31 @@ func (m *pgdbMessageSauceIngredient) SearchData(opts ...pgdb_v1.RecordOptionsFun
 func (m *pgdbMessageSauceIngredient) Dialect() pgdb_v1.Dialect {
 	return pgdb_v1.DialectOrDefault(m.dialect)
 }
+func (m *pgdbMessageSauceIngredient) PKSK() string {
+	var sb strings.Builder
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("models_food_v1_sauce_ingredient")
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetTenantId())
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetId())
+
+	cfv2 := sb.String()
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("examplesauce")
+
+	cfv3 := sb.String()
+
+	return cfv2 + "|" + cfv3
+}
 
 type SauceIngredientDB struct {
 	tableName string
@@ -4994,6 +5077,31 @@ func (m *pgdbMessageGarlicIngredient) SearchData(opts ...pgdb_v1.RecordOptionsFu
 
 func (m *pgdbMessageGarlicIngredient) Dialect() pgdb_v1.Dialect {
 	return pgdb_v1.DialectOrDefault(m.dialect)
+}
+func (m *pgdbMessageGarlicIngredient) PKSK() string {
+	var sb strings.Builder
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("models_food_v1_garlic_ingredient")
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetTenantId())
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetId())
+
+	cfv2 := sb.String()
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("examplecheese")
+
+	cfv3 := sb.String()
+
+	return cfv2 + "|" + cfv3
 }
 
 type GarlicIngredientDB struct {
@@ -6341,6 +6449,31 @@ func (m *pgdbMessageCheeseIngredient) SearchData(opts ...pgdb_v1.RecordOptionsFu
 
 func (m *pgdbMessageCheeseIngredient) Dialect() pgdb_v1.Dialect {
 	return pgdb_v1.DialectOrDefault(m.dialect)
+}
+func (m *pgdbMessageCheeseIngredient) PKSK() string {
+	var sb strings.Builder
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("models_food_v1_cheese_ingredient")
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetTenantId())
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetId())
+
+	cfv2 := sb.String()
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("examplecheese")
+
+	cfv3 := sb.String()
+
+	return cfv2 + "|" + cfv3
 }
 
 type CheeseIngredientDB struct {

--- a/example/models/food/v1/pksk_test.go
+++ b/example/models/food/v1/pksk_test.go
@@ -1,0 +1,71 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pgdb_v1 "github.com/ductone/protoc-gen-pgdb/pgdb/v1"
+)
+
+// TestPKSKMatchesRecord asserts the generated cheap PKSK() helper produces
+// exactly what Postgres stores: Record()["pb$pk"] | Record()["pb$sk"] (which is
+// what the pb$pksk generated column, `pb$pk || '|' || pb$sk`, evaluates to).
+// Covers composite partition keys, sk_const sort keys, and created-at / KSUID
+// partitioned tables, across both dialects (the key columns are
+// dialect-independent, so both must agree).
+func TestPKSKMatchesRecord(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  pgdb_v1.DBReflectMessage
+	}{
+		{
+			name: "composite_pk_with_sk_const",
+			msg:  Pasta_builder{TenantId: "t1", Id: "p1"}.Build(),
+		},
+		{
+			name: "pasta_ingredient",
+			msg:  PastaIngredient_builder{TenantId: "t1", Id: "pi1", PastaId: "p1", IngredientId: "i1"}.Build(),
+		},
+		{
+			name: "sauce_ingredient",
+			msg:  SauceIngredient_builder{TenantId: "t2", Id: "s2", SourceAddr: "1.2.3.4"}.Build(),
+		},
+		{
+			name: "created_at_partitioned",
+			msg:  GarlicIngredient_builder{TenantId: "t3", Id: "g3"}.Build(),
+		},
+		{
+			name: "ksuid_partitioned",
+			msg:  CheeseIngredient_builder{TenantId: "t4", Id: "c4", EventId: "evt4"}.Build(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, dialect := range []pgdb_v1.Dialect{pgdb_v1.DialectV13, pgdb_v1.DialectV17} {
+				m := tc.msg.DBReflect(dialect)
+				record, err := m.Record()
+				require.NoError(t, err)
+
+				pk, ok := record["pb$pk"].(string)
+				require.True(t, ok, "pb$pk should be a string")
+				sk, ok := record["pb$sk"].(string)
+				require.True(t, ok, "pb$sk should be a string")
+
+				pk2, ok := m.(pgdb_v1.PrimaryKeyer)
+				require.True(t, ok, "top-level message should implement PrimaryKeyer")
+				require.Equal(t, pk+"|"+sk, pk2.PKSK(),
+					"PKSK() must equal Record pb$pk|pb$sk for dialect %s", dialect)
+			}
+		})
+	}
+}
+
+// TestPKSKNestedOnly confirms nested-only messages (which have no primary key)
+// do not implement PrimaryKeyer — the PKSK method is not generated for them.
+func TestPKSKNestedOnly(t *testing.T) {
+	m := PastaIngredient_ModelEmbedding_builder{}.Build().DBReflect(pgdb_v1.DialectV13)
+	_, ok := m.(pgdb_v1.PrimaryKeyer)
+	require.False(t, ok, "nested-only message must not implement PrimaryKeyer")
+}

--- a/example/models/zoo/v1/zoo.pb.pgdb.go
+++ b/example/models/zoo/v1/zoo.pb.pgdb.go
@@ -765,6 +765,31 @@ func (m *pgdbMessageShop) SearchData(opts ...pgdb_v1.RecordOptionsFunc) []*pgdb_
 func (m *pgdbMessageShop) Dialect() pgdb_v1.Dialect {
 	return pgdb_v1.DialectOrDefault(m.dialect)
 }
+func (m *pgdbMessageShop) PKSK() string {
+	var sb strings.Builder
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("models_zoo_v1_shop")
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetTenantId())
+
+	_, _ = sb.WriteString(":")
+
+	_, _ = sb.WriteString(m.self.GetId())
+
+	cfv2 := sb.String()
+
+	sb.Reset()
+
+	_, _ = sb.WriteString("example")
+
+	cfv3 := sb.String()
+
+	return cfv2 + "|" + cfv3
+}
 
 type ShopDB struct {
 	tableName string

--- a/internal/pgdb/pgdb_message.go
+++ b/internal/pgdb/pgdb_message.go
@@ -18,6 +18,11 @@ type messageTemplateContext struct {
 	SearchFields            []*searchFieldContext
 	Indexes                 []*indexContext
 	WantRecordStringBuilder bool
+	// PKField and SKField are the pb$pk / pb$sk key columns, pulled out of
+	// Fields so the template can emit a cheap standalone PKSK() builder. Both
+	// nil for nested-only messages (which have no primary key).
+	PKField *fieldContext
+	SKField *fieldContext
 }
 
 func (module *Module) renderMessage(ctx pgsgo.Context, w io.Writer, in pgs.File, m pgs.Message, ix *importTracker) error {
@@ -47,12 +52,25 @@ func (module *Module) renderMessage(ctx pgsgo.Context, w io.Writer, in pgs.File,
 		SearchFields:            getSearchFields(ctx, m),
 		Indexes:                 module.getMessageIndexes(ctx, m, ix),
 		WantRecordStringBuilder: wantRecordStringBuilder,
+		PKField:                 findFieldByDBName(fields, "pk"),
+		SKField:                 findFieldByDBName(fields, "sk"),
 	}
 	return templates["message.tmpl"].Execute(w, c)
 }
 
 func getMessageType(ctx pgsgo.Context, m pgs.Message) string {
 	return "pgdbMessage" + ctx.Name(m).String()
+}
+
+// findFieldByDBName returns the field whose Postgres column name matches, or nil
+// (e.g. nested-only messages have no pk/sk columns).
+func findFieldByDBName(fields []*fieldContext, name string) *fieldContext {
+	for _, f := range fields {
+		if f.DB != nil && f.DB.Name == name {
+			return f
+		}
+	}
+	return nil
 }
 
 type varNamer struct {

--- a/internal/pgdb/templates/message.tmpl
+++ b/internal/pgdb/templates/message.tmpl
@@ -91,3 +91,12 @@ func (m *{{.MessageType}}) SearchData(opts ...pgdb_v1.RecordOptionsFunc) ([]*pgd
 func (m *{{.MessageType}}) Dialect() pgdb_v1.Dialect {
     return pgdb_v1.DialectOrDefault(m.dialect)
 }
+
+{{- if .PKField }}
+func (m *{{.MessageType}}) PKSK() string {
+    var sb strings.Builder
+    {{ .PKField.Convert.CodeForValue }}
+    {{ .SKField.Convert.CodeForValue }}
+    return {{ .PKField.Convert.VarForValue }} + "|" + {{ .SKField.Convert.VarForValue }}
+}
+{{- end }}

--- a/pgdb/v1/insert_test.go
+++ b/pgdb/v1/insert_test.go
@@ -76,6 +76,18 @@ func (m *mockMessage) Dialect() Dialect {
 	return m.dialect
 }
 
+func (m *mockMessage) PKSK() string {
+	pk := m.pk
+	if pk == "" {
+		pk = "pk"
+	}
+	sk := m.sk
+	if sk == "" {
+		sk = "sk"
+	}
+	return pk + "|" + sk
+}
+
 func TestInsert(t *testing.T) {
 	t.Parallel()
 	tt := []struct {

--- a/pgdb/v1/message.go
+++ b/pgdb/v1/message.go
@@ -16,6 +16,19 @@ type Message interface {
 	Dialect() Dialect
 }
 
+// PrimaryKeyer is implemented by the reflected Message of every top-level
+// (non-nested-only) proto — i.e. every message that maps to its own Postgres
+// row and therefore has a primary key. Nested-only messages are stored inline
+// and have no key, so they do NOT implement it; type-assert before calling.
+type PrimaryKeyer interface {
+	// PKSK returns the row's primary key as stored in Postgres: the pb$pk and
+	// pb$sk column values joined with "|" (matching the pb$pksk generated
+	// column, `pb$pk || '|' || pb$sk`). It is derived only from the key fields —
+	// no proto marshal, FTS, or search-data computation — so it is much cheaper
+	// than pulling the value out of Record().
+	PKSK() string
+}
+
 type ColumnExpression interface {
 	Identifier() exp.IdentifierExpression
 }


### PR DESCRIPTION
## Motivation

`Message` only exposed the full `Record()` for pulling a row's primary key. `Record()` marshals the proto and builds **every** column — FTS vectors, search data, pb_data — which is far more work than a caller who just wants the `pb$pksk` value needs.

Because there was no cheap key accessor, consumers reached for the **Dynamo** `PartitionKey()`/`SortKey()` methods instead. That's both a layering violation (Postgres code depending on the Dynamo generator) and *wrong for sharded objects*: the Dynamo partition key embeds a shard id (`…:<tenant>:<shard>`) that Postgres does not store (Postgres keeps `…:<tenant>`), so `PartitionKey()|SortKey()` never matches the `pb$pksk` column for a sharded row.

## Change

Add a generated `PKSK() string` method that builds `"pb$pk|pb$sk"` directly from the key fields:

```go
func (m *pgdbMessagePasta) PKSK() string {
    var sb strings.Builder
    sb.Reset()
    _, _ = sb.WriteString("models_food_v1_pasta")
    _, _ = sb.WriteString(":")
    _, _ = sb.WriteString(m.self.GetTenantId())
    _, _ = sb.WriteString(":")
    _, _ = sb.WriteString(m.self.GetId())
    cfv2 := sb.String()
    sb.Reset()
    _, _ = sb.WriteString("example")
    cfv3 := sb.String()
    return cfv2 + "|" + cfv3
}
```

- **Cheap**: pure string concatenation of the key fields — no `proto.Marshal`, no FTS/search computation.
- **Authoritative**: reuses the *same* pk/sk field builders `Record()` uses, so it always equals `Record()["pb$pk"] + "|" + Record()["pb$sk"]` — which is exactly what the `pb$pksk` generated column (`pb$pk || '|' || pb$sk`) evaluates to. Correct for composite keys, `sk_const`, and partitioned tables.
- **Error-free**: key building can't fail (unlike `Record()`), so the signature is a plain `string`.
- **Dialect-independent**: the key columns don't vary by dialect; the helper returns the same value for V13 and V17.

### Nested-only messages don't get it

Rather than live on the `Message` interface, `PKSK()` lives on a new optional interface:

```go
type PrimaryKeyer interface {
    PKSK() string
}
```

Nested-only messages are stored inline (JSONB in a parent row) and have **no primary key**, so the method simply **isn't generated** for them — they don't implement `PrimaryKeyer`. This avoids emitting a useless `PKSK() string { return "" }` on every nested-only type. Consumers type-assert `Message` → `PrimaryKeyer` before calling.

## Implementation

- `pgdb/v1/message.go` — new `PrimaryKeyer` optional interface (not on `Message`).
- `internal/pgdb/pgdb_message.go` — surface the `pk`/`sk` field contexts to the template (`findFieldByDBName`).
- `internal/pgdb/templates/message.tmpl` — emit the method only when the message has a primary key.
- Regenerated example `*.pb.pgdb.go`.
- `example/models/food/v1/pksk_test.go` — asserts `PKSK() == Record pb$pk|pb$sk` across key shapes and both dialects, and that nested-only messages do **not** implement `PrimaryKeyer`.

## Compatibility

`PKSK()` is additive and on a separate optional interface, so existing `Message` implementers are unaffected. Downstream (c1) will bump this dependency, re-run codegen, and switch its `xpgdb.PKSK` helper to type-assert `PrimaryKeyer` and call `PKSK()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)