### PR TITLE
pgdb: only create fts_data GIN index when a message has a full-text field

### DIFF
--- a/example/models/animals/v1/animals.pb.pgdb.go
+++ b/example/models/animals/v1/animals.pb.pgdb.go
@@ -6934,21 +6934,6 @@ func (d *pgdbDescriptorNewspaper) Indexes(opts ...pgdb_v1.IndexOptionsFunc) []*p
 
 	}
 
-	if !io.IsNested {
-
-		rv = append(rv, &pgdb_v1.Index{
-			Name:               io.IndexName("fts_data_newspaper_models_animals_v1_a1025ab6"),
-			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-			IsPrimary:          false,
-			IsUnique:           false,
-			IsDropped:          false,
-			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
-			OverrideExpression: "",
-			WherePredicate:     "",
-		})
-
-	}
-
 	return rv
 }
 
@@ -7443,23 +7428,6 @@ func (x *NewspaperSKSafeOperators) NotBetween(start string, end string) exp.Rang
 
 func (x *NewspaperDBQueryBuilder) SK() *NewspaperSKSafeOperators {
 	return &NewspaperSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type NewspaperFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *NewspaperFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *NewspaperFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *NewspaperDBQueryBuilder) FTSData() *NewspaperFTSDataSafeOperators {
-	return &NewspaperFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type NewspaperTenantIdQueryType struct {

--- a/example/models/animals/v1/schema_test.go
+++ b/example/models/animals/v1/schema_test.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +17,35 @@ import (
 	"github.com/ductone/protoc-gen-pgdb/internal/pgtest"
 	pgdb_v1 "github.com/ductone/protoc-gen-pgdb/pgdb/v1"
 )
+
+// TestFTSDataIndexGatedOnFullText verifies that the fts_data BTREE_GIN index is
+// only created when a message has a direct full-text field. Pet declares
+// full-text fields, so its index is present. Newspaper declares none, so its
+// fts_data column is always NULL and the index would never match — it is not
+// generated at all (existing indexes on already-provisioned tables are left
+// untouched; dropping those is out of scope for this change).
+func TestFTSDataIndexGatedOnFullText(t *testing.T) {
+	ftsIndex := func(d pgdb_v1.Descriptor) *pgdb_v1.Index {
+		for _, idx := range d.Indexes() {
+			// Identify the fts index by the column it actually covers
+			// (pb$fts_data), not a brittle index-name substring.
+			if idx.Method == pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN &&
+				slices.Contains(idx.Columns, "pb$fts_data") {
+				return idx
+			}
+		}
+		return nil
+	}
+
+	petFTS := ftsIndex((*Pet)(nil).DBReflect(pgdb_v1.DialectV13).Descriptor())
+	require.NotNil(t, petFTS,
+		"Pet declares full-text fields; its fts_data GIN index must be created")
+	require.False(t, petFTS.IsDropped, "Pet's fts_data GIN index must not be dropped")
+
+	newsFTS := ftsIndex((*Newspaper)(nil).DBReflect(pgdb_v1.DialectV13).Descriptor())
+	require.Nil(t, newsFTS,
+		"Newspaper has no full-text field; no fts_data GIN index should be generated")
+}
 
 func TestSchemaPet(t *testing.T) {
 	ctx := context.Background()

--- a/example/models/city/v1/city.pb.pgdb.go
+++ b/example/models/city/v1/city.pb.pgdb.go
@@ -10061,21 +10061,6 @@ func (d *pgdbDescriptorAttractionsV2) Indexes(opts ...pgdb_v1.IndexOptionsFunc) 
 
 	}
 
-	if !io.IsNested {
-
-		rv = append(rv, &pgdb_v1.Index{
-			Name:               io.IndexName("fts_data_attractions_v_2_models_city_v1_b495b2b2"),
-			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-			IsPrimary:          false,
-			IsUnique:           false,
-			IsDropped:          false,
-			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
-			OverrideExpression: "",
-			WherePredicate:     "",
-		})
-
-	}
-
 	return rv
 }
 
@@ -10591,23 +10576,6 @@ func (x *AttractionsV2SKSafeOperators) NotBetween(start string, end string) exp.
 
 func (x *AttractionsV2DBQueryBuilder) SK() *AttractionsV2SKSafeOperators {
 	return &AttractionsV2SKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type AttractionsV2FTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *AttractionsV2FTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *AttractionsV2FTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *AttractionsV2DBQueryBuilder) FTSData() *AttractionsV2FTSDataSafeOperators {
-	return &AttractionsV2FTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type AttractionsV2ConfigNameSafeOperators struct {
@@ -11554,21 +11522,6 @@ func (d *pgdbDescriptorNestedOnlyMiddle) Indexes(opts ...pgdb_v1.IndexOptionsFun
 
 	}
 
-	if !io.IsNested {
-
-		rv = append(rv, &pgdb_v1.Index{
-			Name:               io.IndexName("fts_data_nested_only_middle_models_city_dac4a4de"),
-			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-			IsPrimary:          false,
-			IsUnique:           false,
-			IsDropped:          false,
-			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
-			OverrideExpression: "",
-			WherePredicate:     "",
-		})
-
-	}
-
 	return rv
 }
 
@@ -12096,23 +12049,6 @@ func (x *NestedOnlyMiddleSKSafeOperators) NotBetween(start string, end string) e
 
 func (x *NestedOnlyMiddleDBQueryBuilder) SK() *NestedOnlyMiddleSKSafeOperators {
 	return &NestedOnlyMiddleSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type NestedOnlyMiddleFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *NestedOnlyMiddleFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *NestedOnlyMiddleFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *NestedOnlyMiddleDBQueryBuilder) FTSData() *NestedOnlyMiddleFTSDataSafeOperators {
-	return &NestedOnlyMiddleFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type NestedOnlyMiddleOneofFieldSelectorSafeOperators struct {
@@ -12913,21 +12849,6 @@ func (d *pgdbDescriptorNestedOnlyWrapper) Indexes(opts ...pgdb_v1.IndexOptionsFu
 
 	}
 
-	if !io.IsNested {
-
-		rv = append(rv, &pgdb_v1.Index{
-			Name:               io.IndexName("fts_data_nested_only_wrapper_models_cit_ecc71cb1"),
-			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-			IsPrimary:          false,
-			IsUnique:           false,
-			IsDropped:          false,
-			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
-			OverrideExpression: "",
-			WherePredicate:     "",
-		})
-
-	}
-
 	return rv
 }
 
@@ -13455,23 +13376,6 @@ func (x *NestedOnlyWrapperSKSafeOperators) NotBetween(start string, end string) 
 
 func (x *NestedOnlyWrapperDBQueryBuilder) SK() *NestedOnlyWrapperSKSafeOperators {
 	return &NestedOnlyWrapperSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type NestedOnlyWrapperFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *NestedOnlyWrapperFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *NestedOnlyWrapperFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *NestedOnlyWrapperDBQueryBuilder) FTSData() *NestedOnlyWrapperFTSDataSafeOperators {
-	return &NestedOnlyWrapperFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type NestedOnlyWrapperMiddleIdSafeOperators struct {
@@ -14892,21 +14796,6 @@ func (d *pgdbDescriptorDuplicateTypeBugOuter) Indexes(opts ...pgdb_v1.IndexOptio
 
 	}
 
-	if !io.IsNested {
-
-		rv = append(rv, &pgdb_v1.Index{
-			Name:               io.IndexName("fts_data_duplicate_type_bug_outer_model_f76e4fbd"),
-			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-			IsPrimary:          false,
-			IsUnique:           false,
-			IsDropped:          false,
-			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
-			OverrideExpression: "",
-			WherePredicate:     "",
-		})
-
-	}
-
 	rv = append(rv, &pgdb_v1.Index{
 		Name:               io.IndexName("nested_indexed_duplicate_type_bug_outer_a792d04c"),
 		Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE,
@@ -15445,23 +15334,6 @@ func (x *DuplicateTypeBugOuterSKSafeOperators) NotBetween(start string, end stri
 
 func (x *DuplicateTypeBugOuterDBQueryBuilder) SK() *DuplicateTypeBugOuterSKSafeOperators {
 	return &DuplicateTypeBugOuterSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type DuplicateTypeBugOuterFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *DuplicateTypeBugOuterFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *DuplicateTypeBugOuterFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *DuplicateTypeBugOuterDBQueryBuilder) FTSData() *DuplicateTypeBugOuterFTSDataSafeOperators {
-	return &DuplicateTypeBugOuterFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type DuplicateTypeBugOuterNestedIndexedFieldSafeOperators struct {
@@ -16440,21 +16312,6 @@ func (d *pgdbDescriptorEmbeddedWithOwnDB) Indexes(opts ...pgdb_v1.IndexOptionsFu
 
 	}
 
-	if !io.IsNested {
-
-		rv = append(rv, &pgdb_v1.Index{
-			Name:               io.IndexName("fts_data_embedded_with_own_db_models_ci_826a67df"),
-			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-			IsPrimary:          false,
-			IsUnique:           false,
-			IsDropped:          false,
-			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
-			OverrideExpression: "",
-			WherePredicate:     "",
-		})
-
-	}
-
 	return rv
 }
 
@@ -16982,23 +16839,6 @@ func (x *EmbeddedWithOwnDBSKSafeOperators) NotBetween(start string, end string) 
 
 func (x *EmbeddedWithOwnDBDBQueryBuilder) SK() *EmbeddedWithOwnDBSKSafeOperators {
 	return &EmbeddedWithOwnDBSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type EmbeddedWithOwnDBFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *EmbeddedWithOwnDBFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *EmbeddedWithOwnDBFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *EmbeddedWithOwnDBDBQueryBuilder) FTSData() *EmbeddedWithOwnDBFTSDataSafeOperators {
-	return &EmbeddedWithOwnDBFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type EmbeddedWithOwnDBInnerValueSafeOperators struct {
@@ -17647,21 +17487,6 @@ func (d *pgdbDescriptorParentWithEmbeddedDB) Indexes(opts ...pgdb_v1.IndexOption
 
 	}
 
-	if !io.IsNested {
-
-		rv = append(rv, &pgdb_v1.Index{
-			Name:               io.IndexName("fts_data_parent_with_embedded_db_models_a6a4c6f0"),
-			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-			IsPrimary:          false,
-			IsUnique:           false,
-			IsDropped:          false,
-			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
-			OverrideExpression: "",
-			WherePredicate:     "",
-		})
-
-	}
-
 	return rv
 }
 
@@ -18189,23 +18014,6 @@ func (x *ParentWithEmbeddedDBSKSafeOperators) NotBetween(start string, end strin
 
 func (x *ParentWithEmbeddedDBDBQueryBuilder) SK() *ParentWithEmbeddedDBSKSafeOperators {
 	return &ParentWithEmbeddedDBSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type ParentWithEmbeddedDBFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *ParentWithEmbeddedDBFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *ParentWithEmbeddedDBFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *ParentWithEmbeddedDBDBQueryBuilder) FTSData() *ParentWithEmbeddedDBFTSDataSafeOperators {
-	return &ParentWithEmbeddedDBFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type ParentWithEmbeddedDBEmbeddedIdSafeOperators struct {
@@ -19474,21 +19282,6 @@ func (d *pgdbDescriptorDuplicateMethodsBugRoot) Indexes(opts ...pgdb_v1.IndexOpt
 
 	}
 
-	if !io.IsNested {
-
-		rv = append(rv, &pgdb_v1.Index{
-			Name:               io.IndexName("fts_data_duplicate_methods_bug_root_mod_a9ce30bc"),
-			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-			IsPrimary:          false,
-			IsUnique:           false,
-			IsDropped:          false,
-			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
-			OverrideExpression: "",
-			WherePredicate:     "",
-		})
-
-	}
-
 	rv = append(rv, &pgdb_v1.Index{
 		Name:               io.IndexName("middle_indexed_duplicate_methods_bug_ro_b2da4897"),
 		Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE,
@@ -20027,23 +19820,6 @@ func (x *DuplicateMethodsBugRootSKSafeOperators) NotBetween(start string, end st
 
 func (x *DuplicateMethodsBugRootDBQueryBuilder) SK() *DuplicateMethodsBugRootSKSafeOperators {
 	return &DuplicateMethodsBugRootSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type DuplicateMethodsBugRootFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *DuplicateMethodsBugRootFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *DuplicateMethodsBugRootFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *DuplicateMethodsBugRootDBQueryBuilder) FTSData() *DuplicateMethodsBugRootFTSDataSafeOperators {
-	return &DuplicateMethodsBugRootFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type DuplicateMethodsBugRootMiddleIndexedFieldSafeOperators struct {
@@ -21395,21 +21171,6 @@ func (d *pgdbDescriptorDuplicateTypePathsBugRoot) Indexes(opts ...pgdb_v1.IndexO
 
 	}
 
-	if !io.IsNested {
-
-		rv = append(rv, &pgdb_v1.Index{
-			Name:               io.IndexName("fts_data_duplicate_type_paths_bug_root_5ccb240c"),
-			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-			IsPrimary:          false,
-			IsUnique:           false,
-			IsDropped:          false,
-			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
-			OverrideExpression: "",
-			WherePredicate:     "",
-		})
-
-	}
-
 	return rv
 }
 
@@ -21976,23 +21737,6 @@ func (x *DuplicateTypePathsBugRootSKSafeOperators) NotBetween(start string, end 
 
 func (x *DuplicateTypePathsBugRootDBQueryBuilder) SK() *DuplicateTypePathsBugRootSKSafeOperators {
 	return &DuplicateTypePathsBugRootSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type DuplicateTypePathsBugRootFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *DuplicateTypePathsBugRootFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *DuplicateTypePathsBugRootFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *DuplicateTypePathsBugRootDBQueryBuilder) FTSData() *DuplicateTypePathsBugRootFTSDataSafeOperators {
-	return &DuplicateTypePathsBugRootFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type DuplicateTypePathsBugRootChildANestedGrandchildValueSafeOperators struct {

--- a/internal/pgdb/pgdb_index.go
+++ b/internal/pgdb/pgdb_index.go
@@ -210,23 +210,30 @@ func getCommonIndexes(ctx pgsgo.Context, m pgs.Message) ([]*indexContext, error)
 		},
 	}
 
-	ftsIndexName, err := getIndexName(m, "fts_data")
-	if err != nil {
-		return nil, err
-	}
-
-	ftsIndex := &indexContext{
-		ExcludeNested: true,
-		DB: pgdb_v1.Index{
-			Name:    ftsIndexName,
-			Method:  pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-			Columns: []string{"tenant_id", "fts_data"},
-		},
-	}
-
 	// again loop through and look for vector / hnsw indexes
 
-	rv := []*indexContext{primaryIndex, pkskIndexBroken, pkskIndex, ftsIndex}
+	rv := []*indexContext{primaryIndex, pkskIndexBroken, pkskIndex}
+
+	// The fts_data BTREE_GIN index is only useful when the message declares a
+	// direct full-text field. Without one, ftsDataConvert.CodeForValue writes a
+	// literal NULL for the column (same getSearchFields predicate), so a
+	// full-text predicate on fts_data can never match -- the index would only
+	// be maintained on writes, never used for a search. Only create it when a
+	// full-text field exists; messages without one simply never get the index.
+	if len(getSearchFields(ctx, m)) > 0 {
+		ftsIndexName, err := getIndexName(m, "fts_data")
+		if err != nil {
+			return nil, err
+		}
+		rv = append(rv, &indexContext{
+			ExcludeNested: true,
+			DB: pgdb_v1.Index{
+				Name:    ftsIndexName,
+				Method:  pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+				Columns: []string{"tenant_id", "fts_data"},
+			},
+		})
+	}
 
 	// iterate message for vector behavior options
 	for _, field := range m.Fields() {


### PR DESCRIPTION
## Summary

Every pgdb table message gets a `(tenant_id, fts_data)` **BTREE_GIN** index, but the `fts_data` column is only populated when the message declares a **direct full-text field** (`full_text_type != UNSPECIFIED`). Otherwise `ftsDataConvert.CodeForValue` writes a literal `NULL`, so the column is always empty and the GIN index **can never match a row** — it is pure write-amplification (GIN is the most expensive index type to maintain per write).

This gates index **creation** on the same `getSearchFields` predicate the value code already uses: `getCommonIndexes` only appends the `fts_data` index when a full-text field exists.

**Scope:** this stops *creating* the index; it deliberately does **not** drop existing ones. The index is simply omitted from the descriptor (not marked `IsDropped`), so the `Migrations` diff never touches indexes already present on provisioned tables. Dropping those (and re-shaping the generated FTS selector so it can't be *called* on a non-full-text message) are separate follow-ups.

## Change

- `internal/pgdb/pgdb_index.go`: append the `fts_data` index in `getCommonIndexes` only when `len(getSearchFields(ctx, m)) > 0`.
- Regenerated `example/` models: `Newspaper` and the `city.*` messages (no full-text field) no longer emit the index; `Pet` / `ScalarValue` / `Book` keep it.
- Test: asserts the `fts_data` GIN index is present for `Pet` and absent for `Newspaper`.

## Verification

- `go build ./...` passes; `make example` regenerates cleanly (diff limited to removed `fts_data` index blocks on no-full-text messages).
- Pre-existing `fts_test.go` failures in a bare checkout are unrelated — they require a local PostgreSQL binary.