### PR TITLE
pgdb: SearchField() returns nil for messages with no full-text field

### DIFF
--- a/example/models/animals/v1/animals.pb.pgdb.go
+++ b/example/models/animals/v1/animals.pb.pgdb.go
@@ -4698,7 +4698,7 @@ func (d *pgdbDescriptorEBook) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorEBook) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_e_book_models_animals_v1_a344683d", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorEBook) VersioningField() *pgdb_v1.Column {
@@ -4877,7 +4877,7 @@ func (d *pgdbDescriptorPaperBook) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorPaperBook) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_paper_book_models_animals_v1_ba82559d", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorPaperBook) VersioningField() *pgdb_v1.Column {
@@ -6846,7 +6846,7 @@ func (d *pgdbDescriptorNewspaper) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorNewspaper) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_newspaper_models_animals_v1_f52e04fd", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorNewspaper) VersioningField() *pgdb_v1.Column {

--- a/example/models/animals/v1/animals.pb.pgdb.go
+++ b/example/models/animals/v1/animals.pb.pgdb.go
@@ -6934,21 +6934,6 @@ func (d *pgdbDescriptorNewspaper) Indexes(opts ...pgdb_v1.IndexOptionsFunc) []*p
 
 	}
 
-	if !io.IsNested {
-
-		rv = append(rv, &pgdb_v1.Index{
-			Name:               io.IndexName("fts_data_newspaper_models_animals_v1_a1025ab6"),
-			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-			IsPrimary:          false,
-			IsUnique:           false,
-			IsDropped:          false,
-			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
-			OverrideExpression: "",
-			WherePredicate:     "",
-		})
-
-	}
-
 	return rv
 }
 
@@ -7443,23 +7428,6 @@ func (x *NewspaperSKSafeOperators) NotBetween(start string, end string) exp.Rang
 
 func (x *NewspaperDBQueryBuilder) SK() *NewspaperSKSafeOperators {
 	return &NewspaperSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type NewspaperFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *NewspaperFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *NewspaperFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *NewspaperDBQueryBuilder) FTSData() *NewspaperFTSDataSafeOperators {
-	return &NewspaperFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type NewspaperTenantIdQueryType struct {

--- a/example/models/animals/v1/schema_test.go
+++ b/example/models/animals/v1/schema_test.go
@@ -47,6 +47,17 @@ func TestFTSDataIndexGatedOnFullText(t *testing.T) {
 		"Newspaper has no full-text field; no fts_data GIN index should be generated")
 }
 
+// TestSearchFieldGatedOnFullText verifies the descriptor's SearchField() (the
+// generic entry point the FTS query builder uses) returns the fts_data column
+// only for messages with a direct full-text field, and nil otherwise. Consumers
+// already treat a nil SearchField() as "not searchable".
+func TestSearchFieldGatedOnFullText(t *testing.T) {
+	require.NotNil(t, (*Pet)(nil).DBReflect(pgdb_v1.DialectV13).Descriptor().SearchField(),
+		"Pet declares full-text fields; SearchField() must return the fts_data column")
+	require.Nil(t, (*Newspaper)(nil).DBReflect(pgdb_v1.DialectV13).Descriptor().SearchField(),
+		"Newspaper has no full-text field; SearchField() must be nil")
+}
+
 func TestSchemaPet(t *testing.T) {
 	ctx := context.Background()
 	pg, err := pgtest.Start()

--- a/example/models/animals/v1/schema_test.go
+++ b/example/models/animals/v1/schema_test.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +17,35 @@ import (
 	"github.com/ductone/protoc-gen-pgdb/internal/pgtest"
 	pgdb_v1 "github.com/ductone/protoc-gen-pgdb/pgdb/v1"
 )
+
+// TestFTSDataIndexGatedOnFullText verifies that the fts_data BTREE_GIN index is
+// only created when a message has a direct full-text field. Pet declares
+// full-text fields, so its index is present. Newspaper declares none, so its
+// fts_data column is always NULL and the index would never match — it is not
+// generated at all (existing indexes on already-provisioned tables are left
+// untouched; dropping those is out of scope for this change).
+func TestFTSDataIndexGatedOnFullText(t *testing.T) {
+	ftsIndex := func(d pgdb_v1.Descriptor) *pgdb_v1.Index {
+		for _, idx := range d.Indexes() {
+			// Identify the fts index by the column it actually covers
+			// (pb$fts_data), not a brittle index-name substring.
+			if idx.Method == pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN &&
+				slices.Contains(idx.Columns, "pb$fts_data") {
+				return idx
+			}
+		}
+		return nil
+	}
+
+	petFTS := ftsIndex((*Pet)(nil).DBReflect(pgdb_v1.DialectV13).Descriptor())
+	require.NotNil(t, petFTS,
+		"Pet declares full-text fields; its fts_data GIN index must be created")
+	require.False(t, petFTS.IsDropped, "Pet's fts_data GIN index must not be dropped")
+
+	newsFTS := ftsIndex((*Newspaper)(nil).DBReflect(pgdb_v1.DialectV13).Descriptor())
+	require.Nil(t, newsFTS,
+		"Newspaper has no full-text field; no fts_data GIN index should be generated")
+}
 
 func TestSchemaPet(t *testing.T) {
 	ctx := context.Background()

--- a/example/models/city/v1/city.pb.pgdb.go
+++ b/example/models/city/v1/city.pb.pgdb.go
@@ -10061,21 +10061,6 @@ func (d *pgdbDescriptorAttractionsV2) Indexes(opts ...pgdb_v1.IndexOptionsFunc) 
 
 	}
 
-	if !io.IsNested {
-
-		rv = append(rv, &pgdb_v1.Index{
-			Name:               io.IndexName("fts_data_attractions_v_2_models_city_v1_b495b2b2"),
-			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-			IsPrimary:          false,
-			IsUnique:           false,
-			IsDropped:          false,
-			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
-			OverrideExpression: "",
-			WherePredicate:     "",
-		})
-
-	}
-
 	return rv
 }
 
@@ -10591,23 +10576,6 @@ func (x *AttractionsV2SKSafeOperators) NotBetween(start string, end string) exp.
 
 func (x *AttractionsV2DBQueryBuilder) SK() *AttractionsV2SKSafeOperators {
 	return &AttractionsV2SKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type AttractionsV2FTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *AttractionsV2FTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *AttractionsV2FTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *AttractionsV2DBQueryBuilder) FTSData() *AttractionsV2FTSDataSafeOperators {
-	return &AttractionsV2FTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type AttractionsV2ConfigNameSafeOperators struct {
@@ -11554,21 +11522,6 @@ func (d *pgdbDescriptorNestedOnlyMiddle) Indexes(opts ...pgdb_v1.IndexOptionsFun
 
 	}
 
-	if !io.IsNested {
-
-		rv = append(rv, &pgdb_v1.Index{
-			Name:               io.IndexName("fts_data_nested_only_middle_models_city_dac4a4de"),
-			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-			IsPrimary:          false,
-			IsUnique:           false,
-			IsDropped:          false,
-			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
-			OverrideExpression: "",
-			WherePredicate:     "",
-		})
-
-	}
-
 	return rv
 }
 
@@ -12096,23 +12049,6 @@ func (x *NestedOnlyMiddleSKSafeOperators) NotBetween(start string, end string) e
 
 func (x *NestedOnlyMiddleDBQueryBuilder) SK() *NestedOnlyMiddleSKSafeOperators {
 	return &NestedOnlyMiddleSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type NestedOnlyMiddleFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *NestedOnlyMiddleFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *NestedOnlyMiddleFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *NestedOnlyMiddleDBQueryBuilder) FTSData() *NestedOnlyMiddleFTSDataSafeOperators {
-	return &NestedOnlyMiddleFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type NestedOnlyMiddleOneofFieldSelectorSafeOperators struct {
@@ -12913,21 +12849,6 @@ func (d *pgdbDescriptorNestedOnlyWrapper) Indexes(opts ...pgdb_v1.IndexOptionsFu
 
 	}
 
-	if !io.IsNested {
-
-		rv = append(rv, &pgdb_v1.Index{
-			Name:               io.IndexName("fts_data_nested_only_wrapper_models_cit_ecc71cb1"),
-			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-			IsPrimary:          false,
-			IsUnique:           false,
-			IsDropped:          false,
-			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
-			OverrideExpression: "",
-			WherePredicate:     "",
-		})
-
-	}
-
 	return rv
 }
 
@@ -13455,23 +13376,6 @@ func (x *NestedOnlyWrapperSKSafeOperators) NotBetween(start string, end string) 
 
 func (x *NestedOnlyWrapperDBQueryBuilder) SK() *NestedOnlyWrapperSKSafeOperators {
 	return &NestedOnlyWrapperSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type NestedOnlyWrapperFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *NestedOnlyWrapperFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *NestedOnlyWrapperFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *NestedOnlyWrapperDBQueryBuilder) FTSData() *NestedOnlyWrapperFTSDataSafeOperators {
-	return &NestedOnlyWrapperFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type NestedOnlyWrapperMiddleIdSafeOperators struct {
@@ -14892,21 +14796,6 @@ func (d *pgdbDescriptorDuplicateTypeBugOuter) Indexes(opts ...pgdb_v1.IndexOptio
 
 	}
 
-	if !io.IsNested {
-
-		rv = append(rv, &pgdb_v1.Index{
-			Name:               io.IndexName("fts_data_duplicate_type_bug_outer_model_f76e4fbd"),
-			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-			IsPrimary:          false,
-			IsUnique:           false,
-			IsDropped:          false,
-			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
-			OverrideExpression: "",
-			WherePredicate:     "",
-		})
-
-	}
-
 	rv = append(rv, &pgdb_v1.Index{
 		Name:               io.IndexName("nested_indexed_duplicate_type_bug_outer_a792d04c"),
 		Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE,
@@ -15445,23 +15334,6 @@ func (x *DuplicateTypeBugOuterSKSafeOperators) NotBetween(start string, end stri
 
 func (x *DuplicateTypeBugOuterDBQueryBuilder) SK() *DuplicateTypeBugOuterSKSafeOperators {
 	return &DuplicateTypeBugOuterSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type DuplicateTypeBugOuterFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *DuplicateTypeBugOuterFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *DuplicateTypeBugOuterFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *DuplicateTypeBugOuterDBQueryBuilder) FTSData() *DuplicateTypeBugOuterFTSDataSafeOperators {
-	return &DuplicateTypeBugOuterFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type DuplicateTypeBugOuterNestedIndexedFieldSafeOperators struct {
@@ -16440,21 +16312,6 @@ func (d *pgdbDescriptorEmbeddedWithOwnDB) Indexes(opts ...pgdb_v1.IndexOptionsFu
 
 	}
 
-	if !io.IsNested {
-
-		rv = append(rv, &pgdb_v1.Index{
-			Name:               io.IndexName("fts_data_embedded_with_own_db_models_ci_826a67df"),
-			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-			IsPrimary:          false,
-			IsUnique:           false,
-			IsDropped:          false,
-			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
-			OverrideExpression: "",
-			WherePredicate:     "",
-		})
-
-	}
-
 	return rv
 }
 
@@ -16982,23 +16839,6 @@ func (x *EmbeddedWithOwnDBSKSafeOperators) NotBetween(start string, end string) 
 
 func (x *EmbeddedWithOwnDBDBQueryBuilder) SK() *EmbeddedWithOwnDBSKSafeOperators {
 	return &EmbeddedWithOwnDBSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type EmbeddedWithOwnDBFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *EmbeddedWithOwnDBFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *EmbeddedWithOwnDBFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *EmbeddedWithOwnDBDBQueryBuilder) FTSData() *EmbeddedWithOwnDBFTSDataSafeOperators {
-	return &EmbeddedWithOwnDBFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type EmbeddedWithOwnDBInnerValueSafeOperators struct {
@@ -17647,21 +17487,6 @@ func (d *pgdbDescriptorParentWithEmbeddedDB) Indexes(opts ...pgdb_v1.IndexOption
 
 	}
 
-	if !io.IsNested {
-
-		rv = append(rv, &pgdb_v1.Index{
-			Name:               io.IndexName("fts_data_parent_with_embedded_db_models_a6a4c6f0"),
-			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-			IsPrimary:          false,
-			IsUnique:           false,
-			IsDropped:          false,
-			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
-			OverrideExpression: "",
-			WherePredicate:     "",
-		})
-
-	}
-
 	return rv
 }
 
@@ -18189,23 +18014,6 @@ func (x *ParentWithEmbeddedDBSKSafeOperators) NotBetween(start string, end strin
 
 func (x *ParentWithEmbeddedDBDBQueryBuilder) SK() *ParentWithEmbeddedDBSKSafeOperators {
 	return &ParentWithEmbeddedDBSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type ParentWithEmbeddedDBFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *ParentWithEmbeddedDBFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *ParentWithEmbeddedDBFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *ParentWithEmbeddedDBDBQueryBuilder) FTSData() *ParentWithEmbeddedDBFTSDataSafeOperators {
-	return &ParentWithEmbeddedDBFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type ParentWithEmbeddedDBEmbeddedIdSafeOperators struct {
@@ -19474,21 +19282,6 @@ func (d *pgdbDescriptorDuplicateMethodsBugRoot) Indexes(opts ...pgdb_v1.IndexOpt
 
 	}
 
-	if !io.IsNested {
-
-		rv = append(rv, &pgdb_v1.Index{
-			Name:               io.IndexName("fts_data_duplicate_methods_bug_root_mod_a9ce30bc"),
-			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-			IsPrimary:          false,
-			IsUnique:           false,
-			IsDropped:          false,
-			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
-			OverrideExpression: "",
-			WherePredicate:     "",
-		})
-
-	}
-
 	rv = append(rv, &pgdb_v1.Index{
 		Name:               io.IndexName("middle_indexed_duplicate_methods_bug_ro_b2da4897"),
 		Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE,
@@ -20027,23 +19820,6 @@ func (x *DuplicateMethodsBugRootSKSafeOperators) NotBetween(start string, end st
 
 func (x *DuplicateMethodsBugRootDBQueryBuilder) SK() *DuplicateMethodsBugRootSKSafeOperators {
 	return &DuplicateMethodsBugRootSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type DuplicateMethodsBugRootFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *DuplicateMethodsBugRootFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *DuplicateMethodsBugRootFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *DuplicateMethodsBugRootDBQueryBuilder) FTSData() *DuplicateMethodsBugRootFTSDataSafeOperators {
-	return &DuplicateMethodsBugRootFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type DuplicateMethodsBugRootMiddleIndexedFieldSafeOperators struct {
@@ -21395,21 +21171,6 @@ func (d *pgdbDescriptorDuplicateTypePathsBugRoot) Indexes(opts ...pgdb_v1.IndexO
 
 	}
 
-	if !io.IsNested {
-
-		rv = append(rv, &pgdb_v1.Index{
-			Name:               io.IndexName("fts_data_duplicate_type_paths_bug_root_5ccb240c"),
-			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-			IsPrimary:          false,
-			IsUnique:           false,
-			IsDropped:          false,
-			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
-			OverrideExpression: "",
-			WherePredicate:     "",
-		})
-
-	}
-
 	return rv
 }
 
@@ -21976,23 +21737,6 @@ func (x *DuplicateTypePathsBugRootSKSafeOperators) NotBetween(start string, end 
 
 func (x *DuplicateTypePathsBugRootDBQueryBuilder) SK() *DuplicateTypePathsBugRootSKSafeOperators {
 	return &DuplicateTypePathsBugRootSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type DuplicateTypePathsBugRootFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *DuplicateTypePathsBugRootFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *DuplicateTypePathsBugRootFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *DuplicateTypePathsBugRootDBQueryBuilder) FTSData() *DuplicateTypePathsBugRootFTSDataSafeOperators {
-	return &DuplicateTypePathsBugRootFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type DuplicateTypePathsBugRootChildANestedGrandchildValueSafeOperators struct {

--- a/example/models/city/v1/city.pb.pgdb.go
+++ b/example/models/city/v1/city.pb.pgdb.go
@@ -9552,7 +9552,7 @@ func (d *pgdbDescriptorAttractionsConfig) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorAttractionsConfig) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_attractions_config_models_city_v1_4e3f35be", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorAttractionsConfig) VersioningField() *pgdb_v1.Column {
@@ -9973,7 +9973,7 @@ func (d *pgdbDescriptorAttractionsV2) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorAttractionsV2) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_attractions_v_2_models_city_v1_8f82a0e4", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorAttractionsV2) VersioningField() *pgdb_v1.Column {
@@ -10965,7 +10965,7 @@ func (d *pgdbDescriptorNestedOnlyWithOneof) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorNestedOnlyWithOneof) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_nested_only_with_oneof_models_city_v_84bb2985", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorNestedOnlyWithOneof) VersioningField() *pgdb_v1.Column {
@@ -11434,7 +11434,7 @@ func (d *pgdbDescriptorNestedOnlyMiddle) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorNestedOnlyMiddle) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_nested_only_middle_models_city_v1_400b3e49", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorNestedOnlyMiddle) VersioningField() *pgdb_v1.Column {
@@ -12761,7 +12761,7 @@ func (d *pgdbDescriptorNestedOnlyWrapper) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorNestedOnlyWrapper) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_nested_only_wrapper_models_city_v1_7eca246f", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorNestedOnlyWrapper) VersioningField() *pgdb_v1.Column {
@@ -14064,7 +14064,7 @@ func (d *pgdbDescriptorDuplicateTypeBugInner) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorDuplicateTypeBugInner) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_duplicate_type_bug_inner_models_city_60068b25", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorDuplicateTypeBugInner) VersioningField() *pgdb_v1.Column {
@@ -14262,7 +14262,7 @@ func (d *pgdbDescriptorDuplicateTypeBugNested) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorDuplicateTypeBugNested) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_duplicate_type_bug_nested_models_cit_3437a236", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorDuplicateTypeBugNested) VersioningField() *pgdb_v1.Column {
@@ -14708,7 +14708,7 @@ func (d *pgdbDescriptorDuplicateTypeBugOuter) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorDuplicateTypeBugOuter) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_duplicate_type_bug_outer_models_city_d504449c", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorDuplicateTypeBugOuter) VersioningField() *pgdb_v1.Column {
@@ -15807,7 +15807,7 @@ func (d *pgdbDescriptorEmbeddedDBInnerConfig) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorEmbeddedDBInnerConfig) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_embedded_db_inner_config_models_city_12e4a27d", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorEmbeddedDBInnerConfig) VersioningField() *pgdb_v1.Column {
@@ -16224,7 +16224,7 @@ func (d *pgdbDescriptorEmbeddedWithOwnDB) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorEmbeddedWithOwnDB) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_embedded_with_own_db_models_city_v1_2e0a1e29", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorEmbeddedWithOwnDB) VersioningField() *pgdb_v1.Column {
@@ -17399,7 +17399,7 @@ func (d *pgdbDescriptorParentWithEmbeddedDB) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorParentWithEmbeddedDB) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_parent_with_embedded_db_models_city_1f304a2d", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorParentWithEmbeddedDB) VersioningField() *pgdb_v1.Column {
@@ -18550,7 +18550,7 @@ func (d *pgdbDescriptorDuplicateMethodsBugLeaf) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorDuplicateMethodsBugLeaf) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_duplicate_methods_bug_leaf_models_ci_61cd4839", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorDuplicateMethodsBugLeaf) VersioningField() *pgdb_v1.Column {
@@ -18748,7 +18748,7 @@ func (d *pgdbDescriptorDuplicateMethodsBugMiddle) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorDuplicateMethodsBugMiddle) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_duplicate_methods_bug_middle_models_afdc72d1", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorDuplicateMethodsBugMiddle) VersioningField() *pgdb_v1.Column {
@@ -19194,7 +19194,7 @@ func (d *pgdbDescriptorDuplicateMethodsBugRoot) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorDuplicateMethodsBugRoot) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_duplicate_methods_bug_root_models_ci_0c1beebe", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorDuplicateMethodsBugRoot) VersioningField() *pgdb_v1.Column {
@@ -20293,7 +20293,7 @@ func (d *pgdbDescriptorDuplicateTypePathsBugGrandchild) DataField() *pgdb_v1.Col
 }
 
 func (d *pgdbDescriptorDuplicateTypePathsBugGrandchild) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_duplicate_type_paths_bug_grandchild_1f5292af", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorDuplicateTypePathsBugGrandchild) VersioningField() *pgdb_v1.Column {
@@ -20457,7 +20457,7 @@ func (d *pgdbDescriptorDuplicateTypePathsBugChildA) DataField() *pgdb_v1.Column 
 }
 
 func (d *pgdbDescriptorDuplicateTypePathsBugChildA) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_duplicate_type_paths_bug_child_a_mod_19dd4d7b", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorDuplicateTypePathsBugChildA) VersioningField() *pgdb_v1.Column {
@@ -20634,7 +20634,7 @@ func (d *pgdbDescriptorDuplicateTypePathsBugChildB) DataField() *pgdb_v1.Column 
 }
 
 func (d *pgdbDescriptorDuplicateTypePathsBugChildB) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_duplicate_type_paths_bug_child_b_mod_02f63a31", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorDuplicateTypePathsBugChildB) VersioningField() *pgdb_v1.Column {
@@ -21083,7 +21083,7 @@ func (d *pgdbDescriptorDuplicateTypePathsBugRoot) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorDuplicateTypePathsBugRoot) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_duplicate_type_paths_bug_root_models_4a5b53c4", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorDuplicateTypePathsBugRoot) VersioningField() *pgdb_v1.Column {
@@ -22174,7 +22174,7 @@ func (d *pgdbDescriptorAttractionsConfig_Detail) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorAttractionsConfig_Detail) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_detail_models_city_v1_cb331b3f", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorAttractionsConfig_Detail) VersioningField() *pgdb_v1.Column {
@@ -22353,7 +22353,7 @@ func (d *pgdbDescriptorNestedOnlyWithOneof_ChoiceA) DataField() *pgdb_v1.Column 
 }
 
 func (d *pgdbDescriptorNestedOnlyWithOneof_ChoiceA) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_choice_a_models_city_v1_a7e4df45", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorNestedOnlyWithOneof_ChoiceA) VersioningField() *pgdb_v1.Column {
@@ -22532,7 +22532,7 @@ func (d *pgdbDescriptorNestedOnlyWithOneof_ChoiceB) DataField() *pgdb_v1.Column 
 }
 
 func (d *pgdbDescriptorNestedOnlyWithOneof_ChoiceB) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_choice_b_models_city_v1_3593edeb", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorNestedOnlyWithOneof_ChoiceB) VersioningField() *pgdb_v1.Column {

--- a/example/models/food/v1/food.pb.pgdb.go
+++ b/example/models/food/v1/food.pb.pgdb.go
@@ -7232,7 +7232,7 @@ func (d *pgdbDescriptorPastaIngredient_ModelEmbedding) DataField() *pgdb_v1.Colu
 }
 
 func (d *pgdbDescriptorPastaIngredient_ModelEmbedding) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_model_embedding_models_food_v1_de910e59", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorPastaIngredient_ModelEmbedding) VersioningField() *pgdb_v1.Column {

--- a/example/models/zoo/v1/zoo.pb.pgdb.go
+++ b/example/models/zoo/v1/zoo.pb.pgdb.go
@@ -4472,7 +4472,7 @@ func (d *pgdbDescriptorExhibitFilter) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorExhibitFilter) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_exhibit_filter_models_zoo_v1_7c41f0a4", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorExhibitFilter) VersioningField() *pgdb_v1.Column {
@@ -4663,7 +4663,7 @@ func (d *pgdbDescriptorShop_Manager) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorShop_Manager) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_manager_models_zoo_v1_6ccf2214", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorShop_Manager) VersioningField() *pgdb_v1.Column {

--- a/internal/pgdb/pgdb_descriptor.go
+++ b/internal/pgdb/pgdb_descriptor.go
@@ -35,6 +35,7 @@ type descriptorTemplateContext struct {
 	Indexes                     []*indexContext
 	Statistics                  []*statsContext
 	VersioningField             string
+	HasSearchField              bool
 	IsPartitioned               bool
 	IsPartitionedByCreatedAt    bool
 	PartitionedByKsuidFieldName string
@@ -150,6 +151,7 @@ func (module *Module) renderDescriptor(ctx pgsgo.Context, w io.Writer, in pgs.Fi
 		Statistics:                  module.getMessageStatistics(ctx, m, ix),
 		TableName:                   tableName,
 		VersioningField:             vf,
+		HasSearchField:              len(getSearchFields(ctx, m)) > 0,
 		IsPartitioned:               fext.GetPartitioned(),
 		IsPartitionedByCreatedAt:    fext.GetPartitionedByCreatedAt(),
 		PartitionedByKsuidFieldName: fext.GetPartitionedByKsuidFieldName(),

--- a/internal/pgdb/pgdb_index.go
+++ b/internal/pgdb/pgdb_index.go
@@ -210,23 +210,30 @@ func getCommonIndexes(ctx pgsgo.Context, m pgs.Message) ([]*indexContext, error)
 		},
 	}
 
-	ftsIndexName, err := getIndexName(m, "fts_data")
-	if err != nil {
-		return nil, err
-	}
-
-	ftsIndex := &indexContext{
-		ExcludeNested: true,
-		DB: pgdb_v1.Index{
-			Name:    ftsIndexName,
-			Method:  pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-			Columns: []string{"tenant_id", "fts_data"},
-		},
-	}
-
 	// again loop through and look for vector / hnsw indexes
 
-	rv := []*indexContext{primaryIndex, pkskIndexBroken, pkskIndex, ftsIndex}
+	rv := []*indexContext{primaryIndex, pkskIndexBroken, pkskIndex}
+
+	// The fts_data BTREE_GIN index is only useful when the message declares a
+	// direct full-text field. Without one, ftsDataConvert.CodeForValue writes a
+	// literal NULL for the column (same getSearchFields predicate), so a
+	// full-text predicate on fts_data can never match -- the index would only
+	// be maintained on writes, never used for a search. Only create it when a
+	// full-text field exists; messages without one simply never get the index.
+	if len(getSearchFields(ctx, m)) > 0 {
+		ftsIndexName, err := getIndexName(m, "fts_data")
+		if err != nil {
+			return nil, err
+		}
+		rv = append(rv, &indexContext{
+			ExcludeNested: true,
+			DB: pgdb_v1.Index{
+				Name:    ftsIndexName,
+				Method:  pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+				Columns: []string{"tenant_id", "fts_data"},
+			},
+		})
+	}
 
 	// iterate message for vector behavior options
 	for _, field := range m.Fields() {

--- a/internal/pgdb/templates/descriptor.tmpl
+++ b/internal/pgdb/templates/descriptor.tmpl
@@ -170,7 +170,11 @@ func (d *{{.ReceiverType}}) DataField() *pgdb_v1.Column {
 }
 
 func (d *{{.ReceiverType}}) SearchField() *pgdb_v1.Column {
+  {{- if .HasSearchField }}
   return &pgdb_v1.Column{Table: "{{.TableName}}", Name: "pb$fts_data", Type: "tsvector"}
+  {{- else }}
+  return nil
+  {{- end }}
 }
 
 func (d *{{.ReceiverType}}) VersioningField() *pgdb_v1.Column {


### PR DESCRIPTION
Stacked on #148.

## Summary

`Descriptor().SearchField()` is the generic entry point the query builder uses to locate the `fts_data` column for full-text search. It previously returned the column for **every** message — including those with no direct full-text field, whose `fts_data` is always `NULL`. That (a) let FTS queries be built against non-searchable models (a silent no-op) and (b) made `SearchField()` an unreliable "is this searchable?" signal.

This gates it on the same `getSearchFields` predicate used for the `fts_data` index and column value: `SearchField()` now returns **nil** when the message has no direct full-text field. Consumers already treat nil as "not searchable" (e.g. code that checks `SearchField() != nil`).

## Change

- `internal/pgdb/pgdb_descriptor.go` + `templates/descriptor.tmpl`: emit `return nil` from `SearchField()` when the message has no full-text field (new `HasSearchField` context flag).
- Regenerated example: `Newspaper` and the `city.*` messages (no full-text) now return nil from `SearchField()`; `Pet` / `ScalarValue` / `Book` are unchanged.
- Test asserts nil for `Newspaper`, column for `Pet`.

## ⚠️ Consumer requirement (breaking for unguarded callers)

Any caller that dereferences `SearchField()` unconditionally must nil-guard before this reaches it. In particular, query-builder FTS `Select` methods (`FilterQuery`/`Rank`/…) call `SearchField().Identifier()` with no guard today — they must treat a nil `SearchField()` as a **match-nothing** predicate, so an FTS query on a non-searchable model becomes a clean no-op instead of a nil-panic. Behavior is preserved: `… @@ NULL` already excludes all rows today.

## Verification

- `go build ./...` passes; `make example` regenerates cleanly.
- Pre-existing `fts_test.go` failures in a bare checkout are unrelated (require a local PostgreSQL binary).