### PR TITLE
pgdb: drop the fts_data GIN index for messages with no full-text field

### DIFF
--- a/example/models/animals/v1/animals.pb.pgdb.go
+++ b/example/models/animals/v1/animals.pb.pgdb.go
@@ -6934,6 +6934,21 @@ func (d *pgdbDescriptorNewspaper) Indexes(opts ...pgdb_v1.IndexOptionsFunc) []*p
 
 	}
 
+	if !io.IsNested {
+
+		rv = append(rv, &pgdb_v1.Index{
+			Name:               io.IndexName("fts_data_newspaper_models_animals_v1_a1025ab6"),
+			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+			IsPrimary:          false,
+			IsUnique:           false,
+			IsDropped:          true,
+			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
+			OverrideExpression: "",
+			WherePredicate:     "",
+		})
+
+	}
+
 	return rv
 }
 
@@ -7428,6 +7443,23 @@ func (x *NewspaperSKSafeOperators) NotBetween(start string, end string) exp.Rang
 
 func (x *NewspaperDBQueryBuilder) SK() *NewspaperSKSafeOperators {
 	return &NewspaperSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
+}
+
+type NewspaperFTSDataSafeOperators struct {
+	column    string
+	tableName string
+}
+
+func (x *NewspaperFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column)
+}
+
+func (x *NewspaperFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
+}
+
+func (x *NewspaperDBQueryBuilder) FTSData() *NewspaperFTSDataSafeOperators {
+	return &NewspaperFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type NewspaperTenantIdQueryType struct {

--- a/example/models/animals/v1/schema_test.go
+++ b/example/models/animals/v1/schema_test.go
@@ -18,12 +18,11 @@ import (
 	pgdb_v1 "github.com/ductone/protoc-gen-pgdb/pgdb/v1"
 )
 
-// TestFTSDataIndexGatedOnFullText verifies that the fts_data BTREE_GIN index is
-// only created when a message has a direct full-text field. Pet declares
-// full-text fields, so its index is present. Newspaper declares none, so its
-// fts_data column is always NULL and the index would never match — it is not
-// generated at all (existing indexes on already-provisioned tables are left
-// untouched; dropping those is out of scope for this change).
+// TestFTSDataIndexGatedOnFullText verifies the fts_data BTREE_GIN index is only
+// created when a message has a direct full-text field. Pet declares full-text
+// fields, so its index is created. Newspaper declares none, so its fts_data
+// column is always NULL and the index would never match — it is emitted as
+// dropped, so schema apply removes any existing index and never re-creates it.
 func TestFTSDataIndexGatedOnFullText(t *testing.T) {
 	ftsIndex := func(d pgdb_v1.Descriptor) *pgdb_v1.Index {
 		for _, idx := range d.Indexes() {
@@ -43,8 +42,10 @@ func TestFTSDataIndexGatedOnFullText(t *testing.T) {
 	require.False(t, petFTS.IsDropped, "Pet's fts_data GIN index must not be dropped")
 
 	newsFTS := ftsIndex((*Newspaper)(nil).DBReflect(pgdb_v1.DialectV13).Descriptor())
-	require.Nil(t, newsFTS,
-		"Newspaper has no full-text field; no fts_data GIN index should be generated")
+	require.NotNil(t, newsFTS,
+		"Newspaper's fts_data GIN index is still emitted so schema apply can drop it")
+	require.True(t, newsFTS.IsDropped,
+		"Newspaper has no full-text field; its fts_data GIN index must be dropped")
 }
 
 // TestSearchFieldGatedOnFullText verifies the descriptor's SearchField() (the

--- a/example/models/city/v1/city.pb.pgdb.go
+++ b/example/models/city/v1/city.pb.pgdb.go
@@ -10061,6 +10061,21 @@ func (d *pgdbDescriptorAttractionsV2) Indexes(opts ...pgdb_v1.IndexOptionsFunc) 
 
 	}
 
+	if !io.IsNested {
+
+		rv = append(rv, &pgdb_v1.Index{
+			Name:               io.IndexName("fts_data_attractions_v_2_models_city_v1_b495b2b2"),
+			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+			IsPrimary:          false,
+			IsUnique:           false,
+			IsDropped:          true,
+			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
+			OverrideExpression: "",
+			WherePredicate:     "",
+		})
+
+	}
+
 	return rv
 }
 
@@ -10576,6 +10591,23 @@ func (x *AttractionsV2SKSafeOperators) NotBetween(start string, end string) exp.
 
 func (x *AttractionsV2DBQueryBuilder) SK() *AttractionsV2SKSafeOperators {
 	return &AttractionsV2SKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
+}
+
+type AttractionsV2FTSDataSafeOperators struct {
+	column    string
+	tableName string
+}
+
+func (x *AttractionsV2FTSDataSafeOperators) Identifier() exp.IdentifierExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column)
+}
+
+func (x *AttractionsV2FTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
+}
+
+func (x *AttractionsV2DBQueryBuilder) FTSData() *AttractionsV2FTSDataSafeOperators {
+	return &AttractionsV2FTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type AttractionsV2ConfigNameSafeOperators struct {
@@ -11522,6 +11554,21 @@ func (d *pgdbDescriptorNestedOnlyMiddle) Indexes(opts ...pgdb_v1.IndexOptionsFun
 
 	}
 
+	if !io.IsNested {
+
+		rv = append(rv, &pgdb_v1.Index{
+			Name:               io.IndexName("fts_data_nested_only_middle_models_city_dac4a4de"),
+			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+			IsPrimary:          false,
+			IsUnique:           false,
+			IsDropped:          true,
+			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
+			OverrideExpression: "",
+			WherePredicate:     "",
+		})
+
+	}
+
 	return rv
 }
 
@@ -12049,6 +12096,23 @@ func (x *NestedOnlyMiddleSKSafeOperators) NotBetween(start string, end string) e
 
 func (x *NestedOnlyMiddleDBQueryBuilder) SK() *NestedOnlyMiddleSKSafeOperators {
 	return &NestedOnlyMiddleSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
+}
+
+type NestedOnlyMiddleFTSDataSafeOperators struct {
+	column    string
+	tableName string
+}
+
+func (x *NestedOnlyMiddleFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column)
+}
+
+func (x *NestedOnlyMiddleFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
+}
+
+func (x *NestedOnlyMiddleDBQueryBuilder) FTSData() *NestedOnlyMiddleFTSDataSafeOperators {
+	return &NestedOnlyMiddleFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type NestedOnlyMiddleOneofFieldSelectorSafeOperators struct {
@@ -12849,6 +12913,21 @@ func (d *pgdbDescriptorNestedOnlyWrapper) Indexes(opts ...pgdb_v1.IndexOptionsFu
 
 	}
 
+	if !io.IsNested {
+
+		rv = append(rv, &pgdb_v1.Index{
+			Name:               io.IndexName("fts_data_nested_only_wrapper_models_cit_ecc71cb1"),
+			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+			IsPrimary:          false,
+			IsUnique:           false,
+			IsDropped:          true,
+			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
+			OverrideExpression: "",
+			WherePredicate:     "",
+		})
+
+	}
+
 	return rv
 }
 
@@ -13376,6 +13455,23 @@ func (x *NestedOnlyWrapperSKSafeOperators) NotBetween(start string, end string) 
 
 func (x *NestedOnlyWrapperDBQueryBuilder) SK() *NestedOnlyWrapperSKSafeOperators {
 	return &NestedOnlyWrapperSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
+}
+
+type NestedOnlyWrapperFTSDataSafeOperators struct {
+	column    string
+	tableName string
+}
+
+func (x *NestedOnlyWrapperFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column)
+}
+
+func (x *NestedOnlyWrapperFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
+}
+
+func (x *NestedOnlyWrapperDBQueryBuilder) FTSData() *NestedOnlyWrapperFTSDataSafeOperators {
+	return &NestedOnlyWrapperFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type NestedOnlyWrapperMiddleIdSafeOperators struct {
@@ -14796,6 +14892,21 @@ func (d *pgdbDescriptorDuplicateTypeBugOuter) Indexes(opts ...pgdb_v1.IndexOptio
 
 	}
 
+	if !io.IsNested {
+
+		rv = append(rv, &pgdb_v1.Index{
+			Name:               io.IndexName("fts_data_duplicate_type_bug_outer_model_f76e4fbd"),
+			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+			IsPrimary:          false,
+			IsUnique:           false,
+			IsDropped:          true,
+			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
+			OverrideExpression: "",
+			WherePredicate:     "",
+		})
+
+	}
+
 	rv = append(rv, &pgdb_v1.Index{
 		Name:               io.IndexName("nested_indexed_duplicate_type_bug_outer_a792d04c"),
 		Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE,
@@ -15334,6 +15445,23 @@ func (x *DuplicateTypeBugOuterSKSafeOperators) NotBetween(start string, end stri
 
 func (x *DuplicateTypeBugOuterDBQueryBuilder) SK() *DuplicateTypeBugOuterSKSafeOperators {
 	return &DuplicateTypeBugOuterSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
+}
+
+type DuplicateTypeBugOuterFTSDataSafeOperators struct {
+	column    string
+	tableName string
+}
+
+func (x *DuplicateTypeBugOuterFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column)
+}
+
+func (x *DuplicateTypeBugOuterFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
+}
+
+func (x *DuplicateTypeBugOuterDBQueryBuilder) FTSData() *DuplicateTypeBugOuterFTSDataSafeOperators {
+	return &DuplicateTypeBugOuterFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type DuplicateTypeBugOuterNestedIndexedFieldSafeOperators struct {
@@ -16312,6 +16440,21 @@ func (d *pgdbDescriptorEmbeddedWithOwnDB) Indexes(opts ...pgdb_v1.IndexOptionsFu
 
 	}
 
+	if !io.IsNested {
+
+		rv = append(rv, &pgdb_v1.Index{
+			Name:               io.IndexName("fts_data_embedded_with_own_db_models_ci_826a67df"),
+			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+			IsPrimary:          false,
+			IsUnique:           false,
+			IsDropped:          true,
+			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
+			OverrideExpression: "",
+			WherePredicate:     "",
+		})
+
+	}
+
 	return rv
 }
 
@@ -16839,6 +16982,23 @@ func (x *EmbeddedWithOwnDBSKSafeOperators) NotBetween(start string, end string) 
 
 func (x *EmbeddedWithOwnDBDBQueryBuilder) SK() *EmbeddedWithOwnDBSKSafeOperators {
 	return &EmbeddedWithOwnDBSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
+}
+
+type EmbeddedWithOwnDBFTSDataSafeOperators struct {
+	column    string
+	tableName string
+}
+
+func (x *EmbeddedWithOwnDBFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column)
+}
+
+func (x *EmbeddedWithOwnDBFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
+}
+
+func (x *EmbeddedWithOwnDBDBQueryBuilder) FTSData() *EmbeddedWithOwnDBFTSDataSafeOperators {
+	return &EmbeddedWithOwnDBFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type EmbeddedWithOwnDBInnerValueSafeOperators struct {
@@ -17487,6 +17647,21 @@ func (d *pgdbDescriptorParentWithEmbeddedDB) Indexes(opts ...pgdb_v1.IndexOption
 
 	}
 
+	if !io.IsNested {
+
+		rv = append(rv, &pgdb_v1.Index{
+			Name:               io.IndexName("fts_data_parent_with_embedded_db_models_a6a4c6f0"),
+			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+			IsPrimary:          false,
+			IsUnique:           false,
+			IsDropped:          true,
+			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
+			OverrideExpression: "",
+			WherePredicate:     "",
+		})
+
+	}
+
 	return rv
 }
 
@@ -18014,6 +18189,23 @@ func (x *ParentWithEmbeddedDBSKSafeOperators) NotBetween(start string, end strin
 
 func (x *ParentWithEmbeddedDBDBQueryBuilder) SK() *ParentWithEmbeddedDBSKSafeOperators {
 	return &ParentWithEmbeddedDBSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
+}
+
+type ParentWithEmbeddedDBFTSDataSafeOperators struct {
+	column    string
+	tableName string
+}
+
+func (x *ParentWithEmbeddedDBFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column)
+}
+
+func (x *ParentWithEmbeddedDBFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
+}
+
+func (x *ParentWithEmbeddedDBDBQueryBuilder) FTSData() *ParentWithEmbeddedDBFTSDataSafeOperators {
+	return &ParentWithEmbeddedDBFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type ParentWithEmbeddedDBEmbeddedIdSafeOperators struct {
@@ -19282,6 +19474,21 @@ func (d *pgdbDescriptorDuplicateMethodsBugRoot) Indexes(opts ...pgdb_v1.IndexOpt
 
 	}
 
+	if !io.IsNested {
+
+		rv = append(rv, &pgdb_v1.Index{
+			Name:               io.IndexName("fts_data_duplicate_methods_bug_root_mod_a9ce30bc"),
+			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+			IsPrimary:          false,
+			IsUnique:           false,
+			IsDropped:          true,
+			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
+			OverrideExpression: "",
+			WherePredicate:     "",
+		})
+
+	}
+
 	rv = append(rv, &pgdb_v1.Index{
 		Name:               io.IndexName("middle_indexed_duplicate_methods_bug_ro_b2da4897"),
 		Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE,
@@ -19820,6 +20027,23 @@ func (x *DuplicateMethodsBugRootSKSafeOperators) NotBetween(start string, end st
 
 func (x *DuplicateMethodsBugRootDBQueryBuilder) SK() *DuplicateMethodsBugRootSKSafeOperators {
 	return &DuplicateMethodsBugRootSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
+}
+
+type DuplicateMethodsBugRootFTSDataSafeOperators struct {
+	column    string
+	tableName string
+}
+
+func (x *DuplicateMethodsBugRootFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column)
+}
+
+func (x *DuplicateMethodsBugRootFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
+}
+
+func (x *DuplicateMethodsBugRootDBQueryBuilder) FTSData() *DuplicateMethodsBugRootFTSDataSafeOperators {
+	return &DuplicateMethodsBugRootFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type DuplicateMethodsBugRootMiddleIndexedFieldSafeOperators struct {
@@ -21171,6 +21395,21 @@ func (d *pgdbDescriptorDuplicateTypePathsBugRoot) Indexes(opts ...pgdb_v1.IndexO
 
 	}
 
+	if !io.IsNested {
+
+		rv = append(rv, &pgdb_v1.Index{
+			Name:               io.IndexName("fts_data_duplicate_type_paths_bug_root_5ccb240c"),
+			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+			IsPrimary:          false,
+			IsUnique:           false,
+			IsDropped:          true,
+			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
+			OverrideExpression: "",
+			WherePredicate:     "",
+		})
+
+	}
+
 	return rv
 }
 
@@ -21737,6 +21976,23 @@ func (x *DuplicateTypePathsBugRootSKSafeOperators) NotBetween(start string, end 
 
 func (x *DuplicateTypePathsBugRootDBQueryBuilder) SK() *DuplicateTypePathsBugRootSKSafeOperators {
 	return &DuplicateTypePathsBugRootSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
+}
+
+type DuplicateTypePathsBugRootFTSDataSafeOperators struct {
+	column    string
+	tableName string
+}
+
+func (x *DuplicateTypePathsBugRootFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column)
+}
+
+func (x *DuplicateTypePathsBugRootFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
+}
+
+func (x *DuplicateTypePathsBugRootDBQueryBuilder) FTSData() *DuplicateTypePathsBugRootFTSDataSafeOperators {
+	return &DuplicateTypePathsBugRootFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type DuplicateTypePathsBugRootChildANestedGrandchildValueSafeOperators struct {

--- a/internal/pgdb/pgdb_index.go
+++ b/internal/pgdb/pgdb_index.go
@@ -217,23 +217,25 @@ func getCommonIndexes(ctx pgsgo.Context, m pgs.Message) ([]*indexContext, error)
 	// The fts_data BTREE_GIN index is only useful when the message declares a
 	// direct full-text field. Without one, ftsDataConvert.CodeForValue writes a
 	// literal NULL for the column (same getSearchFields predicate), so a
-	// full-text predicate on fts_data can never match -- the index would only
-	// be maintained on writes, never used for a search. Only create it when a
-	// full-text field exists; messages without one simply never get the index.
-	if len(getSearchFields(ctx, m)) > 0 {
-		ftsIndexName, err := getIndexName(m, "fts_data")
-		if err != nil {
-			return nil, err
-		}
-		rv = append(rv, &indexContext{
-			ExcludeNested: true,
-			DB: pgdb_v1.Index{
-				Name:    ftsIndexName,
-				Method:  pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-				Columns: []string{"tenant_id", "fts_data"},
-			},
-		})
+	// full-text predicate on fts_data can never match. For those messages the
+	// index is emitted as dropped: schema apply issues DROP INDEX to remove any
+	// index already present, and never creates it again.
+	ftsIndexName, err := getIndexName(m, "fts_data")
+	if err != nil {
+		return nil, err
 	}
+	ftsIndex := &indexContext{
+		ExcludeNested: true,
+		DB: pgdb_v1.Index{
+			Name:    ftsIndexName,
+			Method:  pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+			Columns: []string{"tenant_id", "fts_data"},
+		},
+	}
+	if len(getSearchFields(ctx, m)) == 0 {
+		ftsIndex.DB.IsDropped = true
+	}
+	rv = append(rv, ftsIndex)
 
 	// iterate message for vector behavior options
 	for _, field := range m.Fields() {


### PR DESCRIPTION
Stacked on #149.

## Summary

Follow-up to the stop-creating change: for messages with no direct full-text field, emit the `fts_data` BTREE_GIN index as `IsDropped: true` instead of omitting it. The schema migration path then issues `DROP INDEX IF EXISTS … CONCURRENTLY` to remove the existing (always-NULL, never-matching) index on already-provisioned tables — and still never creates it for new tables.

This is the deliberate "purge existing" step: the earlier change stops *creating* the dead index (no impact on existing tables); this one *drops* the ones already there.

## Change

- `internal/pgdb/pgdb_index.go`: always emit the fts_data index; set `IsDropped: true` when the message has no full-text field.
- Regenerated example: `Newspaper` and the `city.*` messages now emit the index as dropped; `Pet` / `ScalarValue` / `Book` keep it.
- Test asserts the index is present-and-dropped for `Newspaper`, present-and-not-dropped for `Pet`.

## Rollout note

A consumer regenerating against this emits `DROP INDEX … CONCURRENTLY` for every affected model on the next schema apply — sequence mindful of write load on large tables.

## Verification

- `go build ./...` passes; `make example` regenerates cleanly.
- Pre-existing `fts_test.go` failures in a bare checkout are unrelated (require a local PostgreSQL binary).