### PR TITLE
pgdb: gate SearchField() and drop fts_data GIN index for no-full-text messages

### DIFF
--- a/example/models/animals/v1/animals.pb.pgdb.go
+++ b/example/models/animals/v1/animals.pb.pgdb.go
@@ -7449,23 +7449,6 @@ func (x *NewspaperDBQueryBuilder) SK() *NewspaperSKSafeOperators {
 	return &NewspaperSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
 }
 
-type NewspaperFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *NewspaperFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *NewspaperFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *NewspaperDBQueryBuilder) FTSData() *NewspaperFTSDataSafeOperators {
-	return &NewspaperFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
-}
-
 type NewspaperTenantIdQueryType struct {
 	column    string
 	tableName string

--- a/example/models/animals/v1/animals.pb.pgdb.go
+++ b/example/models/animals/v1/animals.pb.pgdb.go
@@ -4702,7 +4702,7 @@ func (d *pgdbDescriptorEBook) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorEBook) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_e_book_models_animals_v1_a344683d", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorEBook) VersioningField() *pgdb_v1.Column {
@@ -4881,7 +4881,7 @@ func (d *pgdbDescriptorPaperBook) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorPaperBook) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_paper_book_models_animals_v1_ba82559d", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorPaperBook) VersioningField() *pgdb_v1.Column {
@@ -6850,7 +6850,7 @@ func (d *pgdbDescriptorNewspaper) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorNewspaper) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_newspaper_models_animals_v1_f52e04fd", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorNewspaper) VersioningField() *pgdb_v1.Column {
@@ -6932,6 +6932,21 @@ func (d *pgdbDescriptorNewspaper) Indexes(opts ...pgdb_v1.IndexOptionsFunc) []*p
 			IsUnique:           false,
 			IsDropped:          false,
 			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("pk"), io.ColumnName("sk")},
+			OverrideExpression: "",
+			WherePredicate:     "",
+		})
+
+	}
+
+	if !io.IsNested {
+
+		rv = append(rv, &pgdb_v1.Index{
+			Name:               io.IndexName("fts_data_newspaper_models_animals_v1_a1025ab6"),
+			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+			IsPrimary:          false,
+			IsUnique:           false,
+			IsDropped:          true,
+			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
 			OverrideExpression: "",
 			WherePredicate:     "",
 		})
@@ -7432,6 +7447,23 @@ func (x *NewspaperSKSafeOperators) NotBetween(start string, end string) exp.Rang
 
 func (x *NewspaperDBQueryBuilder) SK() *NewspaperSKSafeOperators {
 	return &NewspaperSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
+}
+
+type NewspaperFTSDataSafeOperators struct {
+	column    string
+	tableName string
+}
+
+func (x *NewspaperFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column)
+}
+
+func (x *NewspaperFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
+}
+
+func (x *NewspaperDBQueryBuilder) FTSData() *NewspaperFTSDataSafeOperators {
+	return &NewspaperFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type NewspaperTenantIdQueryType struct {

--- a/example/models/animals/v1/schema_test.go
+++ b/example/models/animals/v1/schema_test.go
@@ -18,12 +18,11 @@ import (
 	pgdb_v1 "github.com/ductone/protoc-gen-pgdb/pgdb/v1"
 )
 
-// TestFTSDataIndexGatedOnFullText verifies that the fts_data BTREE_GIN index is
-// only created when a message has a direct full-text field. Pet declares
-// full-text fields, so its index is present. Newspaper declares none, so its
-// fts_data column is always NULL and the index would never match — it is not
-// generated at all (existing indexes on already-provisioned tables are left
-// untouched; dropping those is out of scope for this change).
+// TestFTSDataIndexGatedOnFullText verifies the fts_data BTREE_GIN index is only
+// created when a message has a direct full-text field. Pet declares full-text
+// fields, so its index is created. Newspaper declares none, so its fts_data
+// column is always NULL and the index would never match — it is emitted as
+// dropped, so schema apply removes any existing index and never re-creates it.
 func TestFTSDataIndexGatedOnFullText(t *testing.T) {
 	ftsIndex := func(d pgdb_v1.Descriptor) *pgdb_v1.Index {
 		for _, idx := range d.Indexes() {
@@ -43,8 +42,21 @@ func TestFTSDataIndexGatedOnFullText(t *testing.T) {
 	require.False(t, petFTS.IsDropped, "Pet's fts_data GIN index must not be dropped")
 
 	newsFTS := ftsIndex((*Newspaper)(nil).DBReflect(pgdb_v1.DialectV13).Descriptor())
-	require.Nil(t, newsFTS,
-		"Newspaper has no full-text field; no fts_data GIN index should be generated")
+	require.NotNil(t, newsFTS,
+		"Newspaper's fts_data GIN index is still emitted so schema apply can drop it")
+	require.True(t, newsFTS.IsDropped,
+		"Newspaper has no full-text field; its fts_data GIN index must be dropped")
+}
+
+// TestSearchFieldGatedOnFullText verifies the descriptor's SearchField() (the
+// generic entry point the FTS query builder uses) returns the fts_data column
+// only for messages with a direct full-text field, and nil otherwise. Consumers
+// already treat a nil SearchField() as "not searchable".
+func TestSearchFieldGatedOnFullText(t *testing.T) {
+	require.NotNil(t, (*Pet)(nil).DBReflect(pgdb_v1.DialectV13).Descriptor().SearchField(),
+		"Pet declares full-text fields; SearchField() must return the fts_data column")
+	require.Nil(t, (*Newspaper)(nil).DBReflect(pgdb_v1.DialectV13).Descriptor().SearchField(),
+		"Newspaper has no full-text field; SearchField() must be nil")
 }
 
 func TestSchemaPet(t *testing.T) {

--- a/example/models/city/v1/city.pb.pgdb.go
+++ b/example/models/city/v1/city.pb.pgdb.go
@@ -9552,7 +9552,7 @@ func (d *pgdbDescriptorAttractionsConfig) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorAttractionsConfig) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_attractions_config_models_city_v1_4e3f35be", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorAttractionsConfig) VersioningField() *pgdb_v1.Column {
@@ -9973,7 +9973,7 @@ func (d *pgdbDescriptorAttractionsV2) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorAttractionsV2) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_attractions_v_2_models_city_v1_8f82a0e4", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorAttractionsV2) VersioningField() *pgdb_v1.Column {
@@ -10055,6 +10055,21 @@ func (d *pgdbDescriptorAttractionsV2) Indexes(opts ...pgdb_v1.IndexOptionsFunc) 
 			IsUnique:           false,
 			IsDropped:          false,
 			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("pk"), io.ColumnName("sk")},
+			OverrideExpression: "",
+			WherePredicate:     "",
+		})
+
+	}
+
+	if !io.IsNested {
+
+		rv = append(rv, &pgdb_v1.Index{
+			Name:               io.IndexName("fts_data_attractions_v_2_models_city_v1_b495b2b2"),
+			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+			IsPrimary:          false,
+			IsUnique:           false,
+			IsDropped:          true,
+			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
 			OverrideExpression: "",
 			WherePredicate:     "",
 		})
@@ -10578,6 +10593,23 @@ func (x *AttractionsV2DBQueryBuilder) SK() *AttractionsV2SKSafeOperators {
 	return &AttractionsV2SKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
 }
 
+type AttractionsV2FTSDataSafeOperators struct {
+	column    string
+	tableName string
+}
+
+func (x *AttractionsV2FTSDataSafeOperators) Identifier() exp.IdentifierExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column)
+}
+
+func (x *AttractionsV2FTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
+}
+
+func (x *AttractionsV2DBQueryBuilder) FTSData() *AttractionsV2FTSDataSafeOperators {
+	return &AttractionsV2FTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
+}
+
 type AttractionsV2ConfigNameSafeOperators struct {
 	column    string
 	tableName string
@@ -10965,7 +10997,7 @@ func (d *pgdbDescriptorNestedOnlyWithOneof) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorNestedOnlyWithOneof) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_nested_only_with_oneof_models_city_v_84bb2985", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorNestedOnlyWithOneof) VersioningField() *pgdb_v1.Column {
@@ -11434,7 +11466,7 @@ func (d *pgdbDescriptorNestedOnlyMiddle) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorNestedOnlyMiddle) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_nested_only_middle_models_city_v1_400b3e49", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorNestedOnlyMiddle) VersioningField() *pgdb_v1.Column {
@@ -11516,6 +11548,21 @@ func (d *pgdbDescriptorNestedOnlyMiddle) Indexes(opts ...pgdb_v1.IndexOptionsFun
 			IsUnique:           false,
 			IsDropped:          false,
 			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("pk"), io.ColumnName("sk")},
+			OverrideExpression: "",
+			WherePredicate:     "",
+		})
+
+	}
+
+	if !io.IsNested {
+
+		rv = append(rv, &pgdb_v1.Index{
+			Name:               io.IndexName("fts_data_nested_only_middle_models_city_dac4a4de"),
+			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+			IsPrimary:          false,
+			IsUnique:           false,
+			IsDropped:          true,
+			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
 			OverrideExpression: "",
 			WherePredicate:     "",
 		})
@@ -12049,6 +12096,23 @@ func (x *NestedOnlyMiddleSKSafeOperators) NotBetween(start string, end string) e
 
 func (x *NestedOnlyMiddleDBQueryBuilder) SK() *NestedOnlyMiddleSKSafeOperators {
 	return &NestedOnlyMiddleSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
+}
+
+type NestedOnlyMiddleFTSDataSafeOperators struct {
+	column    string
+	tableName string
+}
+
+func (x *NestedOnlyMiddleFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column)
+}
+
+func (x *NestedOnlyMiddleFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
+}
+
+func (x *NestedOnlyMiddleDBQueryBuilder) FTSData() *NestedOnlyMiddleFTSDataSafeOperators {
+	return &NestedOnlyMiddleFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type NestedOnlyMiddleOneofFieldSelectorSafeOperators struct {
@@ -12761,7 +12825,7 @@ func (d *pgdbDescriptorNestedOnlyWrapper) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorNestedOnlyWrapper) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_nested_only_wrapper_models_city_v1_7eca246f", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorNestedOnlyWrapper) VersioningField() *pgdb_v1.Column {
@@ -12843,6 +12907,21 @@ func (d *pgdbDescriptorNestedOnlyWrapper) Indexes(opts ...pgdb_v1.IndexOptionsFu
 			IsUnique:           false,
 			IsDropped:          false,
 			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("pk"), io.ColumnName("sk")},
+			OverrideExpression: "",
+			WherePredicate:     "",
+		})
+
+	}
+
+	if !io.IsNested {
+
+		rv = append(rv, &pgdb_v1.Index{
+			Name:               io.IndexName("fts_data_nested_only_wrapper_models_cit_ecc71cb1"),
+			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+			IsPrimary:          false,
+			IsUnique:           false,
+			IsDropped:          true,
+			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
 			OverrideExpression: "",
 			WherePredicate:     "",
 		})
@@ -13376,6 +13455,23 @@ func (x *NestedOnlyWrapperSKSafeOperators) NotBetween(start string, end string) 
 
 func (x *NestedOnlyWrapperDBQueryBuilder) SK() *NestedOnlyWrapperSKSafeOperators {
 	return &NestedOnlyWrapperSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
+}
+
+type NestedOnlyWrapperFTSDataSafeOperators struct {
+	column    string
+	tableName string
+}
+
+func (x *NestedOnlyWrapperFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column)
+}
+
+func (x *NestedOnlyWrapperFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
+}
+
+func (x *NestedOnlyWrapperDBQueryBuilder) FTSData() *NestedOnlyWrapperFTSDataSafeOperators {
+	return &NestedOnlyWrapperFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type NestedOnlyWrapperMiddleIdSafeOperators struct {
@@ -14064,7 +14160,7 @@ func (d *pgdbDescriptorDuplicateTypeBugInner) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorDuplicateTypeBugInner) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_duplicate_type_bug_inner_models_city_60068b25", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorDuplicateTypeBugInner) VersioningField() *pgdb_v1.Column {
@@ -14262,7 +14358,7 @@ func (d *pgdbDescriptorDuplicateTypeBugNested) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorDuplicateTypeBugNested) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_duplicate_type_bug_nested_models_cit_3437a236", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorDuplicateTypeBugNested) VersioningField() *pgdb_v1.Column {
@@ -14708,7 +14804,7 @@ func (d *pgdbDescriptorDuplicateTypeBugOuter) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorDuplicateTypeBugOuter) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_duplicate_type_bug_outer_models_city_d504449c", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorDuplicateTypeBugOuter) VersioningField() *pgdb_v1.Column {
@@ -14790,6 +14886,21 @@ func (d *pgdbDescriptorDuplicateTypeBugOuter) Indexes(opts ...pgdb_v1.IndexOptio
 			IsUnique:           false,
 			IsDropped:          false,
 			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("pk"), io.ColumnName("sk")},
+			OverrideExpression: "",
+			WherePredicate:     "",
+		})
+
+	}
+
+	if !io.IsNested {
+
+		rv = append(rv, &pgdb_v1.Index{
+			Name:               io.IndexName("fts_data_duplicate_type_bug_outer_model_f76e4fbd"),
+			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+			IsPrimary:          false,
+			IsUnique:           false,
+			IsDropped:          true,
+			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
 			OverrideExpression: "",
 			WherePredicate:     "",
 		})
@@ -15336,6 +15447,23 @@ func (x *DuplicateTypeBugOuterDBQueryBuilder) SK() *DuplicateTypeBugOuterSKSafeO
 	return &DuplicateTypeBugOuterSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
 }
 
+type DuplicateTypeBugOuterFTSDataSafeOperators struct {
+	column    string
+	tableName string
+}
+
+func (x *DuplicateTypeBugOuterFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column)
+}
+
+func (x *DuplicateTypeBugOuterFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
+}
+
+func (x *DuplicateTypeBugOuterDBQueryBuilder) FTSData() *DuplicateTypeBugOuterFTSDataSafeOperators {
+	return &DuplicateTypeBugOuterFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
+}
+
 type DuplicateTypeBugOuterNestedIndexedFieldSafeOperators struct {
 	column    string
 	tableName string
@@ -15807,7 +15935,7 @@ func (d *pgdbDescriptorEmbeddedDBInnerConfig) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorEmbeddedDBInnerConfig) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_embedded_db_inner_config_models_city_12e4a27d", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorEmbeddedDBInnerConfig) VersioningField() *pgdb_v1.Column {
@@ -16224,7 +16352,7 @@ func (d *pgdbDescriptorEmbeddedWithOwnDB) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorEmbeddedWithOwnDB) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_embedded_with_own_db_models_city_v1_2e0a1e29", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorEmbeddedWithOwnDB) VersioningField() *pgdb_v1.Column {
@@ -16306,6 +16434,21 @@ func (d *pgdbDescriptorEmbeddedWithOwnDB) Indexes(opts ...pgdb_v1.IndexOptionsFu
 			IsUnique:           false,
 			IsDropped:          false,
 			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("pk"), io.ColumnName("sk")},
+			OverrideExpression: "",
+			WherePredicate:     "",
+		})
+
+	}
+
+	if !io.IsNested {
+
+		rv = append(rv, &pgdb_v1.Index{
+			Name:               io.IndexName("fts_data_embedded_with_own_db_models_ci_826a67df"),
+			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+			IsPrimary:          false,
+			IsUnique:           false,
+			IsDropped:          true,
+			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
 			OverrideExpression: "",
 			WherePredicate:     "",
 		})
@@ -16839,6 +16982,23 @@ func (x *EmbeddedWithOwnDBSKSafeOperators) NotBetween(start string, end string) 
 
 func (x *EmbeddedWithOwnDBDBQueryBuilder) SK() *EmbeddedWithOwnDBSKSafeOperators {
 	return &EmbeddedWithOwnDBSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
+}
+
+type EmbeddedWithOwnDBFTSDataSafeOperators struct {
+	column    string
+	tableName string
+}
+
+func (x *EmbeddedWithOwnDBFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column)
+}
+
+func (x *EmbeddedWithOwnDBFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
+}
+
+func (x *EmbeddedWithOwnDBDBQueryBuilder) FTSData() *EmbeddedWithOwnDBFTSDataSafeOperators {
+	return &EmbeddedWithOwnDBFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type EmbeddedWithOwnDBInnerValueSafeOperators struct {
@@ -17399,7 +17559,7 @@ func (d *pgdbDescriptorParentWithEmbeddedDB) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorParentWithEmbeddedDB) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_parent_with_embedded_db_models_city_1f304a2d", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorParentWithEmbeddedDB) VersioningField() *pgdb_v1.Column {
@@ -17481,6 +17641,21 @@ func (d *pgdbDescriptorParentWithEmbeddedDB) Indexes(opts ...pgdb_v1.IndexOption
 			IsUnique:           false,
 			IsDropped:          false,
 			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("pk"), io.ColumnName("sk")},
+			OverrideExpression: "",
+			WherePredicate:     "",
+		})
+
+	}
+
+	if !io.IsNested {
+
+		rv = append(rv, &pgdb_v1.Index{
+			Name:               io.IndexName("fts_data_parent_with_embedded_db_models_a6a4c6f0"),
+			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+			IsPrimary:          false,
+			IsUnique:           false,
+			IsDropped:          true,
+			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
 			OverrideExpression: "",
 			WherePredicate:     "",
 		})
@@ -18014,6 +18189,23 @@ func (x *ParentWithEmbeddedDBSKSafeOperators) NotBetween(start string, end strin
 
 func (x *ParentWithEmbeddedDBDBQueryBuilder) SK() *ParentWithEmbeddedDBSKSafeOperators {
 	return &ParentWithEmbeddedDBSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
+}
+
+type ParentWithEmbeddedDBFTSDataSafeOperators struct {
+	column    string
+	tableName string
+}
+
+func (x *ParentWithEmbeddedDBFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column)
+}
+
+func (x *ParentWithEmbeddedDBFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
+}
+
+func (x *ParentWithEmbeddedDBDBQueryBuilder) FTSData() *ParentWithEmbeddedDBFTSDataSafeOperators {
+	return &ParentWithEmbeddedDBFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type ParentWithEmbeddedDBEmbeddedIdSafeOperators struct {
@@ -18550,7 +18742,7 @@ func (d *pgdbDescriptorDuplicateMethodsBugLeaf) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorDuplicateMethodsBugLeaf) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_duplicate_methods_bug_leaf_models_ci_61cd4839", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorDuplicateMethodsBugLeaf) VersioningField() *pgdb_v1.Column {
@@ -18748,7 +18940,7 @@ func (d *pgdbDescriptorDuplicateMethodsBugMiddle) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorDuplicateMethodsBugMiddle) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_duplicate_methods_bug_middle_models_afdc72d1", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorDuplicateMethodsBugMiddle) VersioningField() *pgdb_v1.Column {
@@ -19194,7 +19386,7 @@ func (d *pgdbDescriptorDuplicateMethodsBugRoot) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorDuplicateMethodsBugRoot) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_duplicate_methods_bug_root_models_ci_0c1beebe", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorDuplicateMethodsBugRoot) VersioningField() *pgdb_v1.Column {
@@ -19276,6 +19468,21 @@ func (d *pgdbDescriptorDuplicateMethodsBugRoot) Indexes(opts ...pgdb_v1.IndexOpt
 			IsUnique:           false,
 			IsDropped:          false,
 			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("pk"), io.ColumnName("sk")},
+			OverrideExpression: "",
+			WherePredicate:     "",
+		})
+
+	}
+
+	if !io.IsNested {
+
+		rv = append(rv, &pgdb_v1.Index{
+			Name:               io.IndexName("fts_data_duplicate_methods_bug_root_mod_a9ce30bc"),
+			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+			IsPrimary:          false,
+			IsUnique:           false,
+			IsDropped:          true,
+			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
 			OverrideExpression: "",
 			WherePredicate:     "",
 		})
@@ -19822,6 +20029,23 @@ func (x *DuplicateMethodsBugRootDBQueryBuilder) SK() *DuplicateMethodsBugRootSKS
 	return &DuplicateMethodsBugRootSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
 }
 
+type DuplicateMethodsBugRootFTSDataSafeOperators struct {
+	column    string
+	tableName string
+}
+
+func (x *DuplicateMethodsBugRootFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column)
+}
+
+func (x *DuplicateMethodsBugRootFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
+}
+
+func (x *DuplicateMethodsBugRootDBQueryBuilder) FTSData() *DuplicateMethodsBugRootFTSDataSafeOperators {
+	return &DuplicateMethodsBugRootFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
+}
+
 type DuplicateMethodsBugRootMiddleIndexedFieldSafeOperators struct {
 	column    string
 	tableName string
@@ -20293,7 +20517,7 @@ func (d *pgdbDescriptorDuplicateTypePathsBugGrandchild) DataField() *pgdb_v1.Col
 }
 
 func (d *pgdbDescriptorDuplicateTypePathsBugGrandchild) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_duplicate_type_paths_bug_grandchild_1f5292af", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorDuplicateTypePathsBugGrandchild) VersioningField() *pgdb_v1.Column {
@@ -20457,7 +20681,7 @@ func (d *pgdbDescriptorDuplicateTypePathsBugChildA) DataField() *pgdb_v1.Column 
 }
 
 func (d *pgdbDescriptorDuplicateTypePathsBugChildA) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_duplicate_type_paths_bug_child_a_mod_19dd4d7b", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorDuplicateTypePathsBugChildA) VersioningField() *pgdb_v1.Column {
@@ -20634,7 +20858,7 @@ func (d *pgdbDescriptorDuplicateTypePathsBugChildB) DataField() *pgdb_v1.Column 
 }
 
 func (d *pgdbDescriptorDuplicateTypePathsBugChildB) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_duplicate_type_paths_bug_child_b_mod_02f63a31", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorDuplicateTypePathsBugChildB) VersioningField() *pgdb_v1.Column {
@@ -21083,7 +21307,7 @@ func (d *pgdbDescriptorDuplicateTypePathsBugRoot) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorDuplicateTypePathsBugRoot) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_duplicate_type_paths_bug_root_models_4a5b53c4", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorDuplicateTypePathsBugRoot) VersioningField() *pgdb_v1.Column {
@@ -21165,6 +21389,21 @@ func (d *pgdbDescriptorDuplicateTypePathsBugRoot) Indexes(opts ...pgdb_v1.IndexO
 			IsUnique:           false,
 			IsDropped:          false,
 			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("pk"), io.ColumnName("sk")},
+			OverrideExpression: "",
+			WherePredicate:     "",
+		})
+
+	}
+
+	if !io.IsNested {
+
+		rv = append(rv, &pgdb_v1.Index{
+			Name:               io.IndexName("fts_data_duplicate_type_paths_bug_root_5ccb240c"),
+			Method:             pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+			IsPrimary:          false,
+			IsUnique:           false,
+			IsDropped:          true,
+			Columns:            []string{io.ColumnName("tenant_id"), io.ColumnName("fts_data")},
 			OverrideExpression: "",
 			WherePredicate:     "",
 		})
@@ -21739,6 +21978,23 @@ func (x *DuplicateTypePathsBugRootDBQueryBuilder) SK() *DuplicateTypePathsBugRoo
 	return &DuplicateTypePathsBugRootSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
 }
 
+type DuplicateTypePathsBugRootFTSDataSafeOperators struct {
+	column    string
+	tableName string
+}
+
+func (x *DuplicateTypePathsBugRootFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column)
+}
+
+func (x *DuplicateTypePathsBugRootFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
+	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
+}
+
+func (x *DuplicateTypePathsBugRootDBQueryBuilder) FTSData() *DuplicateTypePathsBugRootFTSDataSafeOperators {
+	return &DuplicateTypePathsBugRootFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
+}
+
 type DuplicateTypePathsBugRootChildANestedGrandchildValueSafeOperators struct {
 	column    string
 	tableName string
@@ -22174,7 +22430,7 @@ func (d *pgdbDescriptorAttractionsConfig_Detail) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorAttractionsConfig_Detail) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_detail_models_city_v1_cb331b3f", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorAttractionsConfig_Detail) VersioningField() *pgdb_v1.Column {
@@ -22353,7 +22609,7 @@ func (d *pgdbDescriptorNestedOnlyWithOneof_ChoiceA) DataField() *pgdb_v1.Column 
 }
 
 func (d *pgdbDescriptorNestedOnlyWithOneof_ChoiceA) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_choice_a_models_city_v1_a7e4df45", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorNestedOnlyWithOneof_ChoiceA) VersioningField() *pgdb_v1.Column {
@@ -22532,7 +22788,7 @@ func (d *pgdbDescriptorNestedOnlyWithOneof_ChoiceB) DataField() *pgdb_v1.Column 
 }
 
 func (d *pgdbDescriptorNestedOnlyWithOneof_ChoiceB) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_choice_b_models_city_v1_3593edeb", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorNestedOnlyWithOneof_ChoiceB) VersioningField() *pgdb_v1.Column {

--- a/example/models/city/v1/city.pb.pgdb.go
+++ b/example/models/city/v1/city.pb.pgdb.go
@@ -10593,23 +10593,6 @@ func (x *AttractionsV2DBQueryBuilder) SK() *AttractionsV2SKSafeOperators {
 	return &AttractionsV2SKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
 }
 
-type AttractionsV2FTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *AttractionsV2FTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *AttractionsV2FTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *AttractionsV2DBQueryBuilder) FTSData() *AttractionsV2FTSDataSafeOperators {
-	return &AttractionsV2FTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
-}
-
 type AttractionsV2ConfigNameSafeOperators struct {
 	column    string
 	tableName string
@@ -12098,23 +12081,6 @@ func (x *NestedOnlyMiddleDBQueryBuilder) SK() *NestedOnlyMiddleSKSafeOperators {
 	return &NestedOnlyMiddleSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
 }
 
-type NestedOnlyMiddleFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *NestedOnlyMiddleFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *NestedOnlyMiddleFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *NestedOnlyMiddleDBQueryBuilder) FTSData() *NestedOnlyMiddleFTSDataSafeOperators {
-	return &NestedOnlyMiddleFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
-}
-
 type NestedOnlyMiddleOneofFieldSelectorSafeOperators struct {
 	column    string
 	tableName string
@@ -13455,23 +13421,6 @@ func (x *NestedOnlyWrapperSKSafeOperators) NotBetween(start string, end string) 
 
 func (x *NestedOnlyWrapperDBQueryBuilder) SK() *NestedOnlyWrapperSKSafeOperators {
 	return &NestedOnlyWrapperSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type NestedOnlyWrapperFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *NestedOnlyWrapperFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *NestedOnlyWrapperFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *NestedOnlyWrapperDBQueryBuilder) FTSData() *NestedOnlyWrapperFTSDataSafeOperators {
-	return &NestedOnlyWrapperFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type NestedOnlyWrapperMiddleIdSafeOperators struct {
@@ -15447,23 +15396,6 @@ func (x *DuplicateTypeBugOuterDBQueryBuilder) SK() *DuplicateTypeBugOuterSKSafeO
 	return &DuplicateTypeBugOuterSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
 }
 
-type DuplicateTypeBugOuterFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *DuplicateTypeBugOuterFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *DuplicateTypeBugOuterFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *DuplicateTypeBugOuterDBQueryBuilder) FTSData() *DuplicateTypeBugOuterFTSDataSafeOperators {
-	return &DuplicateTypeBugOuterFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
-}
-
 type DuplicateTypeBugOuterNestedIndexedFieldSafeOperators struct {
 	column    string
 	tableName string
@@ -16984,23 +16916,6 @@ func (x *EmbeddedWithOwnDBDBQueryBuilder) SK() *EmbeddedWithOwnDBSKSafeOperators
 	return &EmbeddedWithOwnDBSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
 }
 
-type EmbeddedWithOwnDBFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *EmbeddedWithOwnDBFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *EmbeddedWithOwnDBFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *EmbeddedWithOwnDBDBQueryBuilder) FTSData() *EmbeddedWithOwnDBFTSDataSafeOperators {
-	return &EmbeddedWithOwnDBFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
-}
-
 type EmbeddedWithOwnDBInnerValueSafeOperators struct {
 	column    string
 	tableName string
@@ -18189,23 +18104,6 @@ func (x *ParentWithEmbeddedDBSKSafeOperators) NotBetween(start string, end strin
 
 func (x *ParentWithEmbeddedDBDBQueryBuilder) SK() *ParentWithEmbeddedDBSKSafeOperators {
 	return &ParentWithEmbeddedDBSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type ParentWithEmbeddedDBFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *ParentWithEmbeddedDBFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *ParentWithEmbeddedDBFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *ParentWithEmbeddedDBDBQueryBuilder) FTSData() *ParentWithEmbeddedDBFTSDataSafeOperators {
-	return &ParentWithEmbeddedDBFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type ParentWithEmbeddedDBEmbeddedIdSafeOperators struct {
@@ -20027,23 +19925,6 @@ func (x *DuplicateMethodsBugRootSKSafeOperators) NotBetween(start string, end st
 
 func (x *DuplicateMethodsBugRootDBQueryBuilder) SK() *DuplicateMethodsBugRootSKSafeOperators {
 	return &DuplicateMethodsBugRootSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type DuplicateMethodsBugRootFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *DuplicateMethodsBugRootFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *DuplicateMethodsBugRootFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *DuplicateMethodsBugRootDBQueryBuilder) FTSData() *DuplicateMethodsBugRootFTSDataSafeOperators {
-	return &DuplicateMethodsBugRootFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type DuplicateMethodsBugRootMiddleIndexedFieldSafeOperators struct {
@@ -21976,23 +21857,6 @@ func (x *DuplicateTypePathsBugRootSKSafeOperators) NotBetween(start string, end 
 
 func (x *DuplicateTypePathsBugRootDBQueryBuilder) SK() *DuplicateTypePathsBugRootSKSafeOperators {
 	return &DuplicateTypePathsBugRootSKSafeOperators{tableName: x.tableName, column: "pb$" + "sk"}
-}
-
-type DuplicateTypePathsBugRootFTSDataSafeOperators struct {
-	column    string
-	tableName string
-}
-
-func (x *DuplicateTypePathsBugRootFTSDataSafeOperators) Identifier() exp.IdentifierExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column)
-}
-
-func (x *DuplicateTypePathsBugRootFTSDataSafeOperators) Eq(v string) exp.BooleanExpression {
-	return exp.NewIdentifierExpression("", x.tableName, x.column).Eq(v)
-}
-
-func (x *DuplicateTypePathsBugRootDBQueryBuilder) FTSData() *DuplicateTypePathsBugRootFTSDataSafeOperators {
-	return &DuplicateTypePathsBugRootFTSDataSafeOperators{tableName: x.tableName, column: "pb$" + "fts_data"}
 }
 
 type DuplicateTypePathsBugRootChildANestedGrandchildValueSafeOperators struct {

--- a/example/models/food/v1/food.pb.pgdb.go
+++ b/example/models/food/v1/food.pb.pgdb.go
@@ -7232,7 +7232,7 @@ func (d *pgdbDescriptorPastaIngredient_ModelEmbedding) DataField() *pgdb_v1.Colu
 }
 
 func (d *pgdbDescriptorPastaIngredient_ModelEmbedding) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_model_embedding_models_food_v1_de910e59", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorPastaIngredient_ModelEmbedding) VersioningField() *pgdb_v1.Column {

--- a/example/models/zoo/v1/zoo.pb.pgdb.go
+++ b/example/models/zoo/v1/zoo.pb.pgdb.go
@@ -4472,7 +4472,7 @@ func (d *pgdbDescriptorExhibitFilter) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorExhibitFilter) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_exhibit_filter_models_zoo_v1_7c41f0a4", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorExhibitFilter) VersioningField() *pgdb_v1.Column {
@@ -4663,7 +4663,7 @@ func (d *pgdbDescriptorShop_Manager) DataField() *pgdb_v1.Column {
 }
 
 func (d *pgdbDescriptorShop_Manager) SearchField() *pgdb_v1.Column {
-	return &pgdb_v1.Column{Table: "pb_manager_models_zoo_v1_6ccf2214", Name: "pb$fts_data", Type: "tsvector"}
+	return nil
 }
 
 func (d *pgdbDescriptorShop_Manager) VersioningField() *pgdb_v1.Column {

--- a/internal/pgdb/pgdb_descriptor.go
+++ b/internal/pgdb/pgdb_descriptor.go
@@ -35,6 +35,7 @@ type descriptorTemplateContext struct {
 	Indexes                     []*indexContext
 	Statistics                  []*statsContext
 	VersioningField             string
+	HasSearchField              bool
 	IsPartitioned               bool
 	IsPartitionedByCreatedAt    bool
 	PartitionedByKsuidFieldName string
@@ -150,6 +151,7 @@ func (module *Module) renderDescriptor(ctx pgsgo.Context, w io.Writer, in pgs.Fi
 		Statistics:                  module.getMessageStatistics(ctx, m, ix),
 		TableName:                   tableName,
 		VersioningField:             vf,
+		HasSearchField:              len(getSearchFields(ctx, m)) > 0,
 		IsPartitioned:               fext.GetPartitioned(),
 		IsPartitionedByCreatedAt:    fext.GetPartitionedByCreatedAt(),
 		PartitionedByKsuidFieldName: fext.GetPartitionedByKsuidFieldName(),

--- a/internal/pgdb/pgdb_index.go
+++ b/internal/pgdb/pgdb_index.go
@@ -217,23 +217,25 @@ func getCommonIndexes(ctx pgsgo.Context, m pgs.Message) ([]*indexContext, error)
 	// The fts_data BTREE_GIN index is only useful when the message declares a
 	// direct full-text field. Without one, ftsDataConvert.CodeForValue writes a
 	// literal NULL for the column (same getSearchFields predicate), so a
-	// full-text predicate on fts_data can never match -- the index would only
-	// be maintained on writes, never used for a search. Only create it when a
-	// full-text field exists; messages without one simply never get the index.
-	if len(getSearchFields(ctx, m)) > 0 {
-		ftsIndexName, err := getIndexName(m, "fts_data")
-		if err != nil {
-			return nil, err
-		}
-		rv = append(rv, &indexContext{
-			ExcludeNested: true,
-			DB: pgdb_v1.Index{
-				Name:    ftsIndexName,
-				Method:  pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
-				Columns: []string{"tenant_id", "fts_data"},
-			},
-		})
+	// full-text predicate on fts_data can never match. For those messages the
+	// index is emitted as dropped: schema apply issues DROP INDEX to remove any
+	// index already present, and never creates it again.
+	ftsIndexName, err := getIndexName(m, "fts_data")
+	if err != nil {
+		return nil, err
 	}
+	ftsIndex := &indexContext{
+		ExcludeNested: true,
+		DB: pgdb_v1.Index{
+			Name:    ftsIndexName,
+			Method:  pgdb_v1.MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+			Columns: []string{"tenant_id", "fts_data"},
+		},
+	}
+	if len(getSearchFields(ctx, m)) == 0 {
+		ftsIndex.DB.IsDropped = true
+	}
+	rv = append(rv, ftsIndex)
 
 	// iterate message for vector behavior options
 	for _, field := range m.Fields() {

--- a/internal/pgdb/pgdb_query_builder.go
+++ b/internal/pgdb/pgdb_query_builder.go
@@ -704,6 +704,12 @@ func (module *Module) getSafeFields(ctx pgsgo.Context, m pgs.Message, ix *import
 	indexByFullName := make(map[string][]pgdb_v1.MessageOptions_Index_IndexMethod)
 	missingIndices := map[string]bool{}
 	for _, idx := range allIndexes {
+		// Tombstone (dropped) indexes exist only to drive DROP INDEX during
+		// migrations; they are not physically present, so they must not
+		// contribute safe query operators to the generated API.
+		if idx.DB.IsDropped {
+			continue
+		}
 		for _, f := range idx.DB.Columns {
 			if _, ok := indexByFullName[f]; !ok {
 				indexByFullName[f] = []pgdb_v1.MessageOptions_Index_IndexMethod{}

--- a/internal/pgdb/templates/descriptor.tmpl
+++ b/internal/pgdb/templates/descriptor.tmpl
@@ -170,7 +170,11 @@ func (d *{{.ReceiverType}}) DataField() *pgdb_v1.Column {
 }
 
 func (d *{{.ReceiverType}}) SearchField() *pgdb_v1.Column {
+  {{- if .HasSearchField }}
   return &pgdb_v1.Column{Table: "{{.TableName}}", Name: "pb$fts_data", Type: "tsvector"}
+  {{- else }}
+  return nil
+  {{- end }}
 }
 
 func (d *{{.ReceiverType}}) VersioningField() *pgdb_v1.Column {

--- a/pgdb/v1/schema_sql.go
+++ b/pgdb/v1/schema_sql.go
@@ -13,9 +13,9 @@ func index2sql(desc Descriptor, idx *Index) string {
 
 	if idx.IsDropped {
 		_, _ = buf.WriteString("DROP INDEX")
-		// WARNING: unique indexes cannot be dropped
-		// concurrently.  Maybe unsafe?
-		if !idx.IsUnique && !desc.IsPartitioned() {
+		// WARNING: unique indexes cannot be dropped concurrently. Neither can
+		// indexes on master partition tables -- mirror the CREATE gating below.
+		if !idx.IsUnique && !desc.IsPartitioned() && !desc.IsPartitionedByCreatedAt() && desc.GetPartitionedByKsuidFieldName() == "" {
 			_, _ = buf.WriteString(" CONCURRENTLY")
 		}
 		_, _ = buf.WriteString(" IF EXISTS ")

--- a/pgdb/v1/schema_sql_test.go
+++ b/pgdb/v1/schema_sql_test.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -560,6 +561,60 @@ SET (
 			result := storageParams2alter(test.desc, test.existingParams)
 			if result != test.expected {
 				t.Errorf("Expected:\n%s\nGot:\n%s", test.expected, result)
+			}
+		})
+	}
+}
+
+func TestIndex2SQLDropConcurrentlyGating(t *testing.T) {
+	// A dropped, non-unique index (e.g. the fts_data tombstone) may only use
+	// DROP INDEX CONCURRENTLY on non-partitioned tables. Master partition
+	// tables -- including partition-by-created-at and partition-by-ksuid --
+	// reject CONCURRENTLY, so the gating must match index2sql's CREATE path.
+	droppedFTS := &Index{
+		Name:      "some_fts_data_idx",
+		IsDropped: true,
+		IsUnique:  false,
+		Method:    MessageOptions_Index_INDEX_METHOD_BTREE_GIN,
+		Columns:   []string{"tenant_id", "fts_data"},
+	}
+
+	tests := []struct {
+		name           string
+		desc           Descriptor
+		wantConcurrent bool
+	}{
+		{
+			name:           "non-partitioned uses CONCURRENTLY",
+			desc:           &mockDescriptor{tableName: "t"},
+			wantConcurrent: true,
+		},
+		{
+			name:           "partitioned master table omits CONCURRENTLY",
+			desc:           &mockDescriptor{tableName: "t", isPartitioned: true},
+			wantConcurrent: false,
+		},
+		{
+			name:           "partitioned-by-created-at omits CONCURRENTLY",
+			desc:           &mockDescriptor{tableName: "t", isPartitionedByCreatedAt: true},
+			wantConcurrent: false,
+		},
+		{
+			name:           "partitioned-by-ksuid omits CONCURRENTLY",
+			desc:           &mockDescriptor{tableName: "t", partitionedByKsuidFieldName: "id"},
+			wantConcurrent: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := index2sql(test.desc, droppedFTS)
+			if !strings.HasPrefix(got, "DROP INDEX") {
+				t.Fatalf("expected a DROP INDEX statement, got:\n%s", got)
+			}
+			hasConcurrent := strings.Contains(got, "CONCURRENTLY")
+			if hasConcurrent != test.wantConcurrent {
+				t.Errorf("CONCURRENTLY present=%v, want %v; sql:\n%s", hasConcurrent, test.wantConcurrent, got)
 			}
 		})
 	}


### PR DESCRIPTION
Consolidates the two follow-ups to #148 into one change. #148 stopped **creating** the `fts_data` BTREE_GIN index on messages with no direct full-text field; this finishes the job.

## Changes

- **`SearchField()` gate** (was #149): the descriptor's `SearchField()` returns `nil` for messages with no direct full-text field, so the generic FTS query builder treats them as not-searchable instead of emitting a predicate against an always-`NULL` `fts_data` column.

- **Drop existing indexes** (was #151): rather than *omitting* the index for no-full-text messages, emit it flagged `IsDropped: true`. This is the only mechanism that removes indexes already present on provisioned tables — `Migrations()` reconciles only indexes named in the descriptor, so an omitted index is invisible to it and lingers forever. With `IsDropped`:
  - fresh tables never create it (`IndexSchema` skips `IsDropped` entries), and
  - existing tables get `DROP INDEX ... CONCURRENTLY`.

  Same pattern as the long-standing `pksk_split` tombstone in `getCommonIndexes`.

## Verification

- `go build ./...`, `go vet ./...` clean.
- New descriptor tests pass: `TestFTSDataIndexGatedOnFullText` (full-text message keeps a live index; no-full-text message emits `IsDropped: true`) and `TestSearchFieldGatedOnFullText` (`SearchField()` non-nil for full-text, nil otherwise).
- Example models regenerated.

Supersedes #149 and #151.