### PR TITLE
Revert "fix: prefix match last search term for multi-dot queries (#139)"

### DIFF
--- a/pgdb/v1/fts.go
+++ b/pgdb/v1/fts.go
@@ -388,7 +388,6 @@ func FullTextSearchQuery(input string, additionalFilters ...jargon.Filter) exp.E
 	tokens := jargon.TokenizeString(input).Filter(filters...).Words()
 
 	var searchTerms []string
-	var dotSplitTerms []string
 
 	for {
 		token, err := tokens.Next()
@@ -400,79 +399,28 @@ func FullTextSearchQuery(input string, additionalFilters ...jargon.Filter) exp.E
 			break
 		}
 
-		raw := token.String()
-
 		t := strings.Map(func(r rune) rune {
 			if unicode.IsDigit(r) || unicode.IsLetter(r) || unicode.IsSpace(r) {
-				return r
+				return r // keep these
 			}
-			return -1
-		}, raw)
 
-		if strings.TrimSpace(t) != "" {
-			searchTerms = append(searchTerms, t)
-		}
+			return -1 // drop everything else
+		}, token.String())
 
-		ds := strings.Map(func(r rune) rune {
-			if unicode.IsDigit(r) || unicode.IsLetter(r) || unicode.IsSpace(r) {
-				return r
-			}
-			if r == '.' {
-				return ' '
-			}
-			return -1
-		}, raw)
-
-		dotSplitTerms = append(dotSplitTerms, strings.Fields(ds)...)
+		searchTerms = append(searchTerms, t)
 	}
 
-	origQuery := buildSearchQuery(searchTerms)
-
-	if len(dotSplitTerms) > len(searchTerms) && len(dotSplitTerms) > 1 {
-		splitQuery := buildSearchQuery(dotSplitTerms)
-		return exp.NewLiteralExpression("(? || ?)", origQuery, splitQuery)
-	}
-
-	return origQuery
-}
-
-func buildSearchQuery(searchTerms []string) exp.Expression {
 	searchText := strings.Join(searchTerms, " ")
 	stemmedSearchText, _ := jargon.TokenizeString(searchText).Filter(stemmer.English).String()
 
-	if len(searchTerms) <= 1 {
-		if searchText == stemmedSearchText {
-			return exp.NewLiteralExpression("(websearch_to_tsquery('simple', ?))", searchText)
-		}
-		return exp.NewLiteralExpression(
-			"(websearch_to_tsquery('simple', ?) || websearch_to_tsquery('simple', ?))",
-			searchText,
-			stemmedSearchText)
-	}
-
-	lastTerm := strings.TrimSpace(searchTerms[len(searchTerms)-1])
-	stemmedTerms := strings.Fields(stemmedSearchText)
-	stemmedLastTerm := lastTerm
-	if len(stemmedTerms) > 0 {
-		stemmedLastTerm = stemmedTerms[len(stemmedTerms)-1]
-	}
-
-	prefixText := strings.Join(searchTerms[:len(searchTerms)-1], " ")
-	stemmedPrefixText := prefixText
-	if len(stemmedTerms) > 1 {
-		stemmedPrefixText = strings.Join(stemmedTerms[:len(stemmedTerms)-1], " ")
-	}
-
 	if searchText == stemmedSearchText {
-		return exp.NewLiteralExpression(
-			"(websearch_to_tsquery('simple', ?) && to_tsquery('simple', ? || ':*'))",
-			prefixText, lastTerm)
+		return exp.NewLiteralExpression("(websearch_to_tsquery('simple', ?))", searchText)
 	}
 
 	return exp.NewLiteralExpression(
-		"((websearch_to_tsquery('simple', ?) && to_tsquery('simple', ? || ':*')) || (websearch_to_tsquery('simple', ?) && to_tsquery('simple', ? || ':*')))",
-		prefixText, lastTerm,
-		stemmedPrefixText, stemmedLastTerm)
+		"(websearch_to_tsquery('simple', ?) || websearch_to_tsquery('simple', ?))",
+		searchText,
+		stemmedSearchText)
 }
 
 type lexeme struct {

--- a/pgdb/v1/fts_test.go
+++ b/pgdb/v1/fts_test.go
@@ -1107,63 +1107,6 @@ func TestAcronymSplitDoc(t *testing.T) {
 	}
 }
 
-func TestSearchMultiDotPrefix(t *testing.T) {
-	pg, err := pgtest.Start()
-	require.NoError(t, err)
-	defer pg.Stop()
-
-	adVector := FullTextSearchVectors([]*SearchContent{
-		{
-			Type:   FieldOptions_FULL_TEXT_TYPE_ENGLISH,
-			Weight: FieldOptions_FULL_TEXT_WEIGHT_HIGH,
-			Value:  "ad.ph02t1.admin.securitygroup",
-		},
-	})
-
-	requireQueryTrue(t, pg, adVector, "ad")
-	requireQueryTrue(t, pg, adVector, "ad.ph02t1")
-	requireQueryTrue(t, pg, adVector, "ad.ph02t1.admin")
-	requireQueryTrue(t, pg, adVector, "ad.ph02t1.admin.se")
-	requireQueryTrue(t, pg, adVector, "ad.ph02t1.admin.sec")
-	requireQueryTrue(t, pg, adVector, "ad.ph02t1.admin.securitygroup")
-	requireQueryTrue(t, pg, adVector, "securitygroup")
-	requireQueryTrue(t, pg, adVector, "admin")
-	requireQueryTrue(t, pg, adVector, "ph02t1")
-	requireQueryFalse(t, pg, adVector, "ad.ph02t1.admin.xyz")
-	requireQueryFalse(t, pg, adVector, "ad.ph02t1.admin.securitygroup.extra")
-	requireQueryFalse(t, pg, adVector, "notfound")
-
-	roleVector := FullTextSearchVectors([]*SearchContent{
-		{
-			Type:   FieldOptions_FULL_TEXT_TYPE_ENGLISH,
-			Weight: FieldOptions_FULL_TEXT_WEIGHT_HIGH,
-			Value:  "roles/bigquery.dataViewer",
-		},
-	})
-
-	requireQueryTrue(t, pg, roleVector, "bigquery")
-	requireQueryTrue(t, pg, roleVector, "roles")
-	requireQueryTrue(t, pg, roleVector, "bigquery.data")
-	requireQueryTrue(t, pg, roleVector, "bigquery.dataV")
-	requireQueryFalse(t, pg, roleVector, "bigquery.admin")
-
-	deepVector := FullTextSearchVectors([]*SearchContent{
-		{
-			Type:   FieldOptions_FULL_TEXT_TYPE_ENGLISH,
-			Weight: FieldOptions_FULL_TEXT_WEIGHT_HIGH,
-			Value:  "org.department.team.project.resource",
-		},
-	})
-
-	requireQueryTrue(t, pg, deepVector, "org.department")
-	requireQueryTrue(t, pg, deepVector, "org.department.team")
-	requireQueryTrue(t, pg, deepVector, "org.department.team.pro")
-	requireQueryTrue(t, pg, deepVector, "org.department.team.project")
-	requireQueryTrue(t, pg, deepVector, "org.department.team.project.res")
-	requireQueryTrue(t, pg, deepVector, "org.department.team.project.resource")
-	requireQueryFalse(t, pg, deepVector, "org.department.team.project.missing")
-}
-
 func requireQueryIs(t *testing.T, pg *pgtest.PG, vectors exp.Expression, input string, matched bool) {
 	qb := goqu.Dialect("postgres")
 	ctx := context.Background()


### PR DESCRIPTION
There are major performance problems with this fix. we need to land a real fix for this edge case that doesn't blow up performance.

This reverts commit cf492ec9ed17827c2702013c220db55f56951d05.

The query-time :* prefix operator added by #139 causes pathological GIN scans: because our fts_data vectors are prefix-dense by design (edge-grams index every prefix of every word), a trailing prefix term like 'prod':* must range-scan and union the posting lists of every lexeme starting with that string. On a large tenant this turned a sub-second search into a 43s query. Prefix expansion belongs at write time in this schema; a follow-up restores multi-dot partial matching via index-side sub-token edge-grams and query-side symbol normalization, without :*.