### PR TITLE
support multi-dot partial search via index-side edge-grams

### DIFF
--- a/pgdb/v1/fts.go
+++ b/pgdb/v1/fts.go
@@ -388,7 +388,6 @@ func FullTextSearchQuery(input string, additionalFilters ...jargon.Filter) exp.E
 	tokens := jargon.TokenizeString(input).Filter(filters...).Words()
 
 	var searchTerms []string
-	var dotSplitTerms []string
 
 	for {
 		token, err := tokens.Next()
@@ -400,79 +399,28 @@ func FullTextSearchQuery(input string, additionalFilters ...jargon.Filter) exp.E
 			break
 		}
 
-		raw := token.String()
-
 		t := strings.Map(func(r rune) rune {
 			if unicode.IsDigit(r) || unicode.IsLetter(r) || unicode.IsSpace(r) {
-				return r
+				return r // keep these
 			}
-			return -1
-		}, raw)
 
-		if strings.TrimSpace(t) != "" {
-			searchTerms = append(searchTerms, t)
-		}
+			return -1 // drop everything else
+		}, token.String())
 
-		ds := strings.Map(func(r rune) rune {
-			if unicode.IsDigit(r) || unicode.IsLetter(r) || unicode.IsSpace(r) {
-				return r
-			}
-			if r == '.' {
-				return ' '
-			}
-			return -1
-		}, raw)
-
-		dotSplitTerms = append(dotSplitTerms, strings.Fields(ds)...)
+		searchTerms = append(searchTerms, t)
 	}
 
-	origQuery := buildSearchQuery(searchTerms)
-
-	if len(dotSplitTerms) > len(searchTerms) && len(dotSplitTerms) > 1 {
-		splitQuery := buildSearchQuery(dotSplitTerms)
-		return exp.NewLiteralExpression("(? || ?)", origQuery, splitQuery)
-	}
-
-	return origQuery
-}
-
-func buildSearchQuery(searchTerms []string) exp.Expression {
 	searchText := strings.Join(searchTerms, " ")
 	stemmedSearchText, _ := jargon.TokenizeString(searchText).Filter(stemmer.English).String()
 
-	if len(searchTerms) <= 1 {
-		if searchText == stemmedSearchText {
-			return exp.NewLiteralExpression("(websearch_to_tsquery('simple', ?))", searchText)
-		}
-		return exp.NewLiteralExpression(
-			"(websearch_to_tsquery('simple', ?) || websearch_to_tsquery('simple', ?))",
-			searchText,
-			stemmedSearchText)
-	}
-
-	lastTerm := strings.TrimSpace(searchTerms[len(searchTerms)-1])
-	stemmedTerms := strings.Fields(stemmedSearchText)
-	stemmedLastTerm := lastTerm
-	if len(stemmedTerms) > 0 {
-		stemmedLastTerm = stemmedTerms[len(stemmedTerms)-1]
-	}
-
-	prefixText := strings.Join(searchTerms[:len(searchTerms)-1], " ")
-	stemmedPrefixText := prefixText
-	if len(stemmedTerms) > 1 {
-		stemmedPrefixText = strings.Join(stemmedTerms[:len(stemmedTerms)-1], " ")
-	}
-
 	if searchText == stemmedSearchText {
-		return exp.NewLiteralExpression(
-			"(websearch_to_tsquery('simple', ?) && to_tsquery('simple', ? || ':*'))",
-			prefixText, lastTerm)
+		return exp.NewLiteralExpression("(websearch_to_tsquery('simple', ?))", searchText)
 	}
 
 	return exp.NewLiteralExpression(
-		"((websearch_to_tsquery('simple', ?) && to_tsquery('simple', ? || ':*')) || (websearch_to_tsquery('simple', ?) && to_tsquery('simple', ? || ':*')))",
-		prefixText, lastTerm,
-		stemmedPrefixText, stemmedLastTerm)
+		"(websearch_to_tsquery('simple', ?) || websearch_to_tsquery('simple', ?))",
+		searchText,
+		stemmedSearchText)
 }
 
 type lexeme struct {

--- a/pgdb/v1/fts.go
+++ b/pgdb/v1/fts.go
@@ -330,6 +330,7 @@ func normalizeVectorDocs(docs []*SearchContent) []lexeme {
 		'/': {},
 		'-': {},
 	}
+	edgeGramFilter := edgegramStream(3)
 	for _, doc := range docs {
 		if doc.Type == FieldOptions_FULL_TEXT_TYPE_ENGLISH_LONG {
 			continue
@@ -337,7 +338,23 @@ func normalizeVectorDocs(docs []*SearchContent) []lexeme {
 		docValue := interfaceToValue(doc.Value)
 		var wordBuffer bytes.Buffer
 		rv = append(rv, camelSplitDoc(docValue, wordBuffer, doc)...)
-		rv = append(rv, symbolsSubTokensSplitDoc(symbols, docValue, wordBuffer, doc)...)
+		subTokens := symbolsSubTokensSplitDoc(symbols, docValue, wordBuffer, doc)
+		rv = append(rv, subTokens...)
+
+		// index-side sub-token edge-grams: since jargon's tokenizer merges dotted/
+		// symbol-separated segments back together (e.g. "admin.securitygroup" stays one
+		// token), a bare sub-token gram like "se" (a prefix of "securitygroup") would
+		// otherwise never get indexed. Emitting the edge-grams here lets query-time
+		// symbol-split terms (see FullTextSearchQuery) match progressively typed,
+		// dotted/underscored/slashed/dashed input without needing a `:*` prefix operator.
+		subTokenGramWeight := lowerWeight(doc.Weight)
+		for _, sub := range subTokens {
+			grams, _ := jargon.TokenizeString(sub.value).Filter(edgeGramFilter).Words().ToSlice()
+			for _, gram := range grams {
+				rv = append(rv, lexeme{gram.String(), sub.pos, subTokenGramWeight})
+			}
+		}
+
 		symbolsFullTokens := symbolsFullTokensSplitDoc(symbols, docValue, wordBuffer, doc)
 		for _, v := range symbolsFullTokens {
 			if len(v.value) >= 1 {
@@ -382,9 +399,21 @@ func FullTextSearchVectors(docs []*SearchContent, additionalFilters ...jargon.Fi
 	return exp.NewLiteralExpression("?::tsvector", sb.String())
 }
 
-func FullTextSearchQuery(input string, additionalFilters ...jargon.Filter) exp.Expression {
-	filters := []jargon.Filter{lowerCaseFilter, ascii.Fold}
-	filters = append(filters, additionalFilters...)
+// symbolQuerySplitChars mirrors the symbol set that normalizeVectorDocs splits index-side
+// documents on. FullTextSearchQuery uses it to build query-time variants that can match
+// the sub-token edge-grams and joined-token prefixes indexed for those documents, without
+// resorting to a `:*` prefix tsquery operator (which can cause pathological GIN scans).
+var symbolQuerySplitChars = map[rune]struct{}{
+	'.': {},
+	'_': {},
+	'/': {},
+	'-': {},
+}
+
+// tokenizeSearchText runs the same jargon tokenize/lowercase/fold/strip pipeline the
+// original (pre-symbol-aware) FullTextSearchQuery used, so each query variant is
+// normalized identically.
+func tokenizeSearchText(input string, filters []jargon.Filter) string {
 	tokens := jargon.TokenizeString(input).Filter(filters...).Words()
 
 	var searchTerms []string
@@ -410,17 +439,78 @@ func FullTextSearchQuery(input string, additionalFilters ...jargon.Filter) exp.E
 		searchTerms = append(searchTerms, t)
 	}
 
-	searchText := strings.Join(searchTerms, " ")
-	stemmedSearchText, _ := jargon.TokenizeString(searchText).Filter(stemmer.English).String()
+	return strings.Join(searchTerms, " ")
+}
 
-	if searchText == stemmedSearchText {
-		return exp.NewLiteralExpression("(websearch_to_tsquery('simple', ?))", searchText)
+func FullTextSearchQuery(input string, additionalFilters ...jargon.Filter) exp.Expression {
+	filters := []jargon.Filter{lowerCaseFilter, ascii.Fold}
+	filters = append(filters, additionalFilters...)
+
+	// origInput: today's back-compat behavior - input as-is.
+	origInput := input
+
+	// splitInput: every symbol rune becomes a space, so "ad.ph02t1.admin.se" becomes
+	// the separate terms "ad ph02t1 admin se". This matches the index-side sub-token
+	// edge-grams emitted by normalizeVectorDocs (e.g. "se" as a gram of "securitygroup").
+	splitInput := strings.Map(func(r rune) rune {
+		if _, ok := symbolQuerySplitChars[r]; ok {
+			return ' '
+		}
+		return r
+	}, input)
+
+	// joinedInput: every symbol rune is deleted (whitespace is preserved), so
+	// "ad.ph02t1.admin.se" becomes the single term "adph02t1adminse". This matches the
+	// joined-token prefix lexemes normalizeVectorDocs already emits for symbol-separated
+	// documents (e.g. "adph02t1adminse" as a prefix of "adph02t1adminsecuritygroup").
+	joinedInput := strings.Map(func(r rune) rune {
+		if _, ok := symbolQuerySplitChars[r]; ok {
+			return -1
+		}
+		return r
+	}, input)
+
+	var texts []string
+	seen := make(map[string]struct{}, 6)
+	addText := func(s string) {
+		if s == "" {
+			return
+		}
+		if _, ok := seen[s]; ok {
+			return
+		}
+		seen[s] = struct{}{}
+		texts = append(texts, s)
 	}
 
-	return exp.NewLiteralExpression(
-		"(websearch_to_tsquery('simple', ?) || websearch_to_tsquery('simple', ?))",
-		searchText,
-		stemmedSearchText)
+	for _, variant := range []string{origInput, splitInput, joinedInput} {
+		searchText := tokenizeSearchText(variant, filters)
+		stemmedSearchText, _ := jargon.TokenizeString(searchText).Filter(stemmer.English).String()
+		addText(searchText)
+		addText(stemmedSearchText)
+	}
+
+	if len(texts) == 0 {
+		return exp.NewLiteralExpression("(websearch_to_tsquery('simple', ?))", "")
+	}
+
+	if len(texts) == 1 {
+		return exp.NewLiteralExpression("(websearch_to_tsquery('simple', ?))", texts[0])
+	}
+
+	sb := strings.Builder{}
+	args := make([]interface{}, 0, len(texts))
+	sb.WriteString("(")
+	for i, t := range texts {
+		if i > 0 {
+			sb.WriteString(" || ")
+		}
+		sb.WriteString("websearch_to_tsquery('simple', ?)")
+		args = append(args, t)
+	}
+	sb.WriteString(")")
+
+	return exp.NewLiteralExpression(sb.String(), args...)
 }
 
 type lexeme struct {

--- a/pgdb/v1/fts_test.go
+++ b/pgdb/v1/fts_test.go
@@ -1107,6 +1107,63 @@ func TestAcronymSplitDoc(t *testing.T) {
 	}
 }
 
+func TestSearchMultiDotPrefix(t *testing.T) {
+	pg, err := pgtest.Start()
+	require.NoError(t, err)
+	defer pg.Stop()
+
+	adVector := FullTextSearchVectors([]*SearchContent{
+		{
+			Type:   FieldOptions_FULL_TEXT_TYPE_ENGLISH,
+			Weight: FieldOptions_FULL_TEXT_WEIGHT_HIGH,
+			Value:  "ad.ph02t1.admin.securitygroup",
+		},
+	})
+
+	requireQueryTrue(t, pg, adVector, "ad")
+	requireQueryTrue(t, pg, adVector, "ad.ph02t1")
+	requireQueryTrue(t, pg, adVector, "ad.ph02t1.admin")
+	requireQueryTrue(t, pg, adVector, "ad.ph02t1.admin.se")
+	requireQueryTrue(t, pg, adVector, "ad.ph02t1.admin.sec")
+	requireQueryTrue(t, pg, adVector, "ad.ph02t1.admin.securitygroup")
+	requireQueryTrue(t, pg, adVector, "securitygroup")
+	requireQueryTrue(t, pg, adVector, "admin")
+	requireQueryTrue(t, pg, adVector, "ph02t1")
+	requireQueryFalse(t, pg, adVector, "ad.ph02t1.admin.xyz")
+	requireQueryFalse(t, pg, adVector, "ad.ph02t1.admin.securitygroup.extra")
+	requireQueryFalse(t, pg, adVector, "notfound")
+
+	roleVector := FullTextSearchVectors([]*SearchContent{
+		{
+			Type:   FieldOptions_FULL_TEXT_TYPE_ENGLISH,
+			Weight: FieldOptions_FULL_TEXT_WEIGHT_HIGH,
+			Value:  "roles/bigquery.dataViewer",
+		},
+	})
+
+	requireQueryTrue(t, pg, roleVector, "bigquery")
+	requireQueryTrue(t, pg, roleVector, "roles")
+	requireQueryTrue(t, pg, roleVector, "bigquery.data")
+	requireQueryTrue(t, pg, roleVector, "bigquery.dataV")
+	requireQueryFalse(t, pg, roleVector, "bigquery.admin")
+
+	deepVector := FullTextSearchVectors([]*SearchContent{
+		{
+			Type:   FieldOptions_FULL_TEXT_TYPE_ENGLISH,
+			Weight: FieldOptions_FULL_TEXT_WEIGHT_HIGH,
+			Value:  "org.department.team.project.resource",
+		},
+	})
+
+	requireQueryTrue(t, pg, deepVector, "org.department")
+	requireQueryTrue(t, pg, deepVector, "org.department.team")
+	requireQueryTrue(t, pg, deepVector, "org.department.team.pro")
+	requireQueryTrue(t, pg, deepVector, "org.department.team.project")
+	requireQueryTrue(t, pg, deepVector, "org.department.team.project.res")
+	requireQueryTrue(t, pg, deepVector, "org.department.team.project.resource")
+	requireQueryFalse(t, pg, deepVector, "org.department.team.project.missing")
+}
+
 func requireQueryIs(t *testing.T, pg *pgtest.PG, vectors exp.Expression, input string, matched bool) {
 	qb := goqu.Dialect("postgres")
 	ctx := context.Background()
@@ -1130,6 +1187,85 @@ func requireQueryTrue(t *testing.T, pg *pgtest.PG, vectors exp.Expression, query
 
 func requireQueryFalse(t *testing.T, pg *pgtest.PG, vectors exp.Expression, query string) {
 	requireQueryIs(t, pg, vectors, query, false)
+}
+
+// containsLexeme reports whether lexemes contains one with the given value, regardless
+// of position/weight.
+func containsLexeme(lexemes []lexeme, value string) bool {
+	for _, l := range lexemes {
+		if l.value == value {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSubTokenEdgeGrams is a non-DB unit test (no postgres binary required) covering
+// Change 1: normalizeVectorDocs must additionally emit edge-grams of each dot-separated
+// sub-token (e.g. "se", "sec", ... "securitygroup" as grams of the "securitygroup"
+// sub-token), on top of the pre-existing joined-token prefix lexemes (e.g.
+// "adph02t1adminse" as a prefix of the joined token "adph02t1adminsecuritygroup"). This
+// is what lets query-side symbol-split terms (Change 2) match without a `:*` operator.
+func TestSubTokenEdgeGrams(t *testing.T) {
+	doc := &SearchContent{
+		Type:   FieldOptions_FULL_TEXT_TYPE_ENGLISH,
+		Weight: FieldOptions_FULL_TEXT_WEIGHT_HIGH,
+		Value:  "ad.ph02t1.admin.securitygroup",
+	}
+
+	lexemes := normalizeVectorDocs([]*SearchContent{doc})
+
+	for _, want := range []string{"se", "sec", "securitygroup", "adph02t1adminse"} {
+		assert.True(t, containsLexeme(lexemes, want), "expected lexeme %q to be present in %#v", want, lexemes)
+	}
+}
+
+// renderQuerySQL renders a FullTextSearchQuery expression to SQL via the goqu postgres
+// dialect, mirroring how requireQueryIs renders vectors/queries for the DB-backed tests.
+// goqu's default dialect interpolates literal arguments directly into the SQL string (see
+// requireQueryIs, which discards the returned args), so assertions here are made against
+// the rendered query string.
+func renderQuerySQL(t *testing.T, q exp.Expression) string {
+	t.Helper()
+	qb := goqu.Dialect("postgres")
+	query, _, err := qb.Select(goqu.L("?", q)).ToSQL()
+	require.NoError(t, err)
+	return query
+}
+
+// TestFullTextSearchQueryDotVariants is a non-DB unit test covering Change 2: querying a
+// multi-dot input must render both the joined variant (matches the joined-token prefix
+// lexemes already indexed pre-fix) and the space-split variant (matches the new sub-token
+// edge-gram lexemes from Change 1).
+func TestFullTextSearchQueryDotVariants(t *testing.T) {
+	query := renderQuerySQL(t, FullTextSearchQuery("ad.ph02t1.admin.se"))
+
+	assert.Contains(t, query, "adph02t1adminse", "expected joined variant term in query: %s", query)
+	assert.Contains(t, query, "ad ph02t1 admin se", "expected split variant term in query: %s", query)
+}
+
+// TestFullTextSearchQueryNoPrefixOperator is a guard test: no rendered query, for any of a
+// representative set of inputs (multi-word, dotted, slashed, snake_case, unicode, single
+// word), may contain the `:*` prefix tsquery operator that caused the pathological GIN
+// scans fixed by this change.
+func TestFullTextSearchQueryNoPrefixOperator(t *testing.T) {
+	inputs := []string{
+		"dataplane prod",
+		"ad.ph02t1.admin.se",
+		"roles/bigquery.dataViewer",
+		"foo_bar_baz_21_quux",
+		"café.naïve_zürich",
+		"single",
+		" ",
+		"!12345",
+	}
+
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			query := renderQuerySQL(t, FullTextSearchQuery(input))
+			assert.NotContains(t, query, ":*", "query for %q must not contain the :* prefix operator: %s", input, query)
+		})
+	}
 }
 
 func FuzzFullTextSearchQuery(f *testing.F) {

--- a/pgdb/v1/fts_test.go
+++ b/pgdb/v1/fts_test.go
@@ -1107,63 +1107,6 @@ func TestAcronymSplitDoc(t *testing.T) {
 	}
 }
 
-func TestSearchMultiDotPrefix(t *testing.T) {
-	pg, err := pgtest.Start()
-	require.NoError(t, err)
-	defer pg.Stop()
-
-	adVector := FullTextSearchVectors([]*SearchContent{
-		{
-			Type:   FieldOptions_FULL_TEXT_TYPE_ENGLISH,
-			Weight: FieldOptions_FULL_TEXT_WEIGHT_HIGH,
-			Value:  "ad.ph02t1.admin.securitygroup",
-		},
-	})
-
-	requireQueryTrue(t, pg, adVector, "ad")
-	requireQueryTrue(t, pg, adVector, "ad.ph02t1")
-	requireQueryTrue(t, pg, adVector, "ad.ph02t1.admin")
-	requireQueryTrue(t, pg, adVector, "ad.ph02t1.admin.se")
-	requireQueryTrue(t, pg, adVector, "ad.ph02t1.admin.sec")
-	requireQueryTrue(t, pg, adVector, "ad.ph02t1.admin.securitygroup")
-	requireQueryTrue(t, pg, adVector, "securitygroup")
-	requireQueryTrue(t, pg, adVector, "admin")
-	requireQueryTrue(t, pg, adVector, "ph02t1")
-	requireQueryFalse(t, pg, adVector, "ad.ph02t1.admin.xyz")
-	requireQueryFalse(t, pg, adVector, "ad.ph02t1.admin.securitygroup.extra")
-	requireQueryFalse(t, pg, adVector, "notfound")
-
-	roleVector := FullTextSearchVectors([]*SearchContent{
-		{
-			Type:   FieldOptions_FULL_TEXT_TYPE_ENGLISH,
-			Weight: FieldOptions_FULL_TEXT_WEIGHT_HIGH,
-			Value:  "roles/bigquery.dataViewer",
-		},
-	})
-
-	requireQueryTrue(t, pg, roleVector, "bigquery")
-	requireQueryTrue(t, pg, roleVector, "roles")
-	requireQueryTrue(t, pg, roleVector, "bigquery.data")
-	requireQueryTrue(t, pg, roleVector, "bigquery.dataV")
-	requireQueryFalse(t, pg, roleVector, "bigquery.admin")
-
-	deepVector := FullTextSearchVectors([]*SearchContent{
-		{
-			Type:   FieldOptions_FULL_TEXT_TYPE_ENGLISH,
-			Weight: FieldOptions_FULL_TEXT_WEIGHT_HIGH,
-			Value:  "org.department.team.project.resource",
-		},
-	})
-
-	requireQueryTrue(t, pg, deepVector, "org.department")
-	requireQueryTrue(t, pg, deepVector, "org.department.team")
-	requireQueryTrue(t, pg, deepVector, "org.department.team.pro")
-	requireQueryTrue(t, pg, deepVector, "org.department.team.project")
-	requireQueryTrue(t, pg, deepVector, "org.department.team.project.res")
-	requireQueryTrue(t, pg, deepVector, "org.department.team.project.resource")
-	requireQueryFalse(t, pg, deepVector, "org.department.team.project.missing")
-}
-
 func requireQueryIs(t *testing.T, pg *pgtest.PG, vectors exp.Expression, input string, matched bool) {
 	qb := goqu.Dialect("postgres")
 	ctx := context.Background()


### PR DESCRIPTION
Context

#139 made progressive typing of dotted identifiers work (ad.ph02t1.admin.se → ad.ph02t1.admin.securitygroup) by appending a :* prefix operator to the last search term. On a prefix-dense index like ours (edge-grams mean every word contributes all its prefixes as lexemes), :* forces GIN to range-scan and union the posting lists of every lexeme starting with the term — a trailing common token like prod turned a sub-second search into a 43s query on a 2.1M-row tenant (OPS-2310). #139 is reverted in the PR below this one; this PR restores the multi-dot matching it provided, keeping all queries as exact lexeme lookups.

Root cause of the original miss

jargon's tokenizer merges dotted segments (admin.securitygroup stays one token), so edge-grams were computed on the merged string and a bare sub-token gram like se (prefix of securitygroup) was never indexed. #139 papered over that at query time; this fixes it at write time.

Changes

- Index side (normalizeVectorDocs): additionally emit edge-grams for each symbol-split sub-token (securitygroup → s, se, sec, …) at lowered weight. Purely additive — new vectors are a strict superset of old ones.
- Query side (FullTextSearchQuery): build symbol-aware variants of the input — original, symbols→spaces (ad ph02t1 admin se), and symbols-deleted (adph02t1adminse) — each with its stemmed twin, deduped and OR'd as exact websearch_to_tsquery('simple', …) terms. No :* anywhere. Inputs without symbols produce byte-identical queries to pre-#139 behavior.

Deployment properties

- The joined variant matches joined-token prefix lexemes already present in existing indexes, so from-the-start dotted typing works immediately on old rows — no backfill required.
- The split variant matches the new sub-token edge-grams on rows written after this change.
- Known gap: mid-path partials (admin.se) won't match rows indexed before this change until they're rewritten or backfilled. (#139 covered this case at query time; accepted trade-off.)

Testing

- TestSearchMultiDotPrefix restored verbatim from #139 (DB-backed, runs in CI).
- New unit tests: sub-token edge-gram emission, dot-variant query construction, and a table-driven guard asserting generated queries never contain :*.
