### PR TITLE
fix(fts): index-time prefix ladder + drop query-time :* (OPS-2314)

### DIFF
--- a/pgdb/v1/fts.go
+++ b/pgdb/v1/fts.go
@@ -337,7 +337,17 @@ func normalizeVectorDocs(docs []*SearchContent) []lexeme {
 		docValue := interfaceToValue(doc.Value)
 		var wordBuffer bytes.Buffer
 		rv = append(rv, camelSplitDoc(docValue, wordBuffer, doc)...)
-		rv = append(rv, symbolsSubTokensSplitDoc(symbols, docValue, wordBuffer, doc)...)
+		subTokens := symbolsSubTokensSplitDoc(symbols, docValue, wordBuffer, doc)
+		for _, v := range subTokens {
+			// Index the prefix ladder of each bare sub-token (securitygroup ->
+			// s, se, sec, ...) so a trailing partial search term matches as an
+			// exact lexeme rather than a `:*` prefix scan, which unions unbounded
+			// GIN posting lists for a common prefix.
+			for i := 1; i < len(v.value); i++ {
+				rv = append(rv, lexeme{v.value[0:i], v.pos, lowerWeight(doc.Weight)})
+			}
+		}
+		rv = append(rv, subTokens...)
 		symbolsFullTokens := symbolsFullTokensSplitDoc(symbols, docValue, wordBuffer, doc)
 		for _, v := range symbolsFullTokens {
 			if len(v.value) >= 1 {
@@ -465,12 +475,12 @@ func buildSearchQuery(searchTerms []string) exp.Expression {
 
 	if searchText == stemmedSearchText {
 		return exp.NewLiteralExpression(
-			"(websearch_to_tsquery('simple', ?) && to_tsquery('simple', ? || ':*'))",
+			"(websearch_to_tsquery('simple', ?) && to_tsquery('simple', ?))",
 			prefixText, lastTerm)
 	}
 
 	return exp.NewLiteralExpression(
-		"((websearch_to_tsquery('simple', ?) && to_tsquery('simple', ? || ':*')) || (websearch_to_tsquery('simple', ?) && to_tsquery('simple', ? || ':*')))",
+		"((websearch_to_tsquery('simple', ?) && to_tsquery('simple', ?)) || (websearch_to_tsquery('simple', ?) && to_tsquery('simple', ?)))",
 		prefixText, lastTerm,
 		stemmedPrefixText, stemmedLastTerm)
 }

--- a/pgdb/v1/fts_test.go
+++ b/pgdb/v1/fts_test.go
@@ -1189,6 +1189,22 @@ func requireQueryFalse(t *testing.T, pg *pgtest.PG, vectors exp.Expression, quer
 	requireQueryIs(t, pg, vectors, query, false)
 }
 
+// TestSearchTrailingTermNoPrefixExplosion asserts the emitted tsquery no longer
+// uses a `:*` prefix match on the trailing term. normalizeVectorDocs now indexes
+// the prefix ladder of each bare sub-token, so the trailing partial matches as an
+// exact single-posting-list lexeme; `:*` would instead union the GIN posting lists
+// of every lexeme sharing the prefix, which is unbounded on a common prefix.
+// End-to-end recall for the trailing partial is covered by TestSearchMultiDotPrefix.
+func TestSearchTrailingTermNoPrefixExplosion(t *testing.T) {
+	qb := goqu.Dialect("postgres")
+	for _, input := range []string{"prod environment", "ad.ph02t1.admin.se"} {
+		query, args, err := qb.Select(FullTextSearchQuery(input)).ToSQL()
+		require.NoError(t, err, "input=%q", input)
+		assert.NotContains(t, query, ":*", "emitted tsquery for %q must not use a prefix match: %s", input, query)
+		_ = args
+	}
+}
+
 func FuzzFullTextSearchQuery(f *testing.F) {
 	testcases := []string{"Hello, world", " ", "!12345", "☃️ snowman!"}
 	for _, tc := range testcases {


### PR DESCRIPTION
> [!WARNING]
> **DEPLOYMENT ORDERING IS LOAD-BEARING — DO NOT MERGE-AND-SHIP AS ONE STEP.**
> The tsvector is generated at **row-write time** by this generated code and stored in the row. Existing rows keep their old (`:*`-dependent) vectors until they are re-marshaled. **The index-side prefix ladder must ship AND all FTS tsvector columns must be backfilled / re-indexed BEFORE the query-side `:*` removal reaches prod.** Removing `:*` against un-backfilled rows silently drops trailing-partial recall (typeahead stops matching) with no error.
>
> **Recommended: split this into two mergeable PRs.**
> 1. **Index-side first** — land the `normalizeVectorDocs` prefix ladder, release it, then **backfill / re-index every FTS tsvector column**.
> 2. **Query-side after backfill** — only then land the `buildSearchQuery` `:*` removal.
>
> **This draft is the combined proof** that the two-sided change is correct and green end-to-end. It is intentionally NOT for merge as-is.

## Summary

Fixes the FTS trailing-term prefix explosion (OPS-2314) by moving prefix expansion from **query time** to **index time**:

- **Index side** (`normalizeVectorDocs`, `pgdb/v1/fts.go`): emit the prefix ladder of each bare sub-token (`securitygroup` → `s, se, sec, …`), weighted `lowerWeight(doc.Weight)` to match existing gram weighting.
- **Query side** (`buildSearchQuery`, `pgdb/v1/fts.go`): drop `|| ':*'` from both the non-stemmed and stemmed branches. The trailing term is now an **exact single-posting-list lexeme lookup**.
- **New test** (`TestSearchTrailingTermNoPrefixExplosion`): asserts the emitted tsquery contains no `:*`.

## Root cause

- protoc-gen-pgdb **#139** introduced the query-time `to_tsquery('simple', ? || ':*')` prefix match on the trailing search term.
- `:*` forces GIN to **union the posting lists of every lexeme sharing the prefix** (`prod` → prod, production, product, prod-xyz, …). For a common prefix this is an **unbounded** union → GBs scanned.
- Observed **~53s → 102ms** after the fix on prod ClickHouse data.

## Why the naive fix does NOT work

The obvious one-liner — just drop `:*` from the query — was **tested against real Postgres and REGRESSES IGA-1440.** The premise that the index already stores a bare per-word prefix ladder is **false**: the index emits full sub-token lexemes + 3-char sliding-window grams + compound-prefix ladders, but **not** the bare `s, se, sec, …` ladder. So with `:*` removed and no index change, `TestSearchMultiDotPrefix` fails on exactly the partial-trailing cases:

```
ad.ph02t1.admin.se   should match ad.ph02t1.admin.securitygroup  -> false
bigquery.data        should match bigquery.dataviewer            -> false
bigquery.dataV       should match bigquery.dataviewer            -> false
```

The two-sided change (this PR) makes the bare ladder exist at index time, so exact-match recall is preserved **and** the posting-list union is eliminated.

## Caveats (from the validated prototype writeup)

1. **tsvector size / write amplification.** Prefix ladders on every bare sub-token grow the tsvector (additive with the existing compound-prefix ladder; some overlap). The **1 MB `tsvectorMaxMegabytes` cap** truncates lexemes when exceeded, which could drop tail lexemes on very long values. Measure vector-size delta on representative large tenants before shipping the backfill; consider capping ladder length if bloat is significant. Exact-match query cost is unaffected by ladder length.
2. **`ENGLISH_LONG` / `EXACT` behavior change.** These types intentionally get no grams. `buildSearchQuery` is field-type-agnostic, so after `:*` removal a trailing partial on an `ENGLISH_LONG` / `EXACT` field matches only full words (no partial typeahead). Confirm no product surface relies on trailing-prefix typeahead over long-text / exact fields.
3. **Byte-vs-rune slicing.** The ladder uses `v.value[0:i]` byte slicing (matching the existing `symbolsFullTokensSplitDoc` prefix block). On multibyte sub-tokens this can split a rune (harmless byte-fragment lexemes; fuzz seeds pass, Postgres tolerates). Sub-tokens are lowercased identifier-ish text so risk is low; a rune-aware slice is cheap hardening for the real PR.

## Test results

```
go test ./pgdb/v1/... -run 'FTS|Search|MultiDot' -v
--- PASS: TestSearchBigQueryDoc
--- PASS: TestSearchSymbols (+ all subtests)
--- PASS: TestSearchEmpty
--- PASS: TestSearchCamelCase
--- PASS: TestSearchSnakeCase
--- PASS: TestSearchPathsFull
--- PASS: TestSearchMultiDotPrefix                  <-- IGA-1440 GREEN with :* removed
--- PASS: TestSearchTrailingTermNoPrefixExplosion   <-- new: asserts no :* in emitted SQL
--- PASS: FuzzFullTextSearchQuery / FuzzFullTextSearchVectors (seeds)
ok  github.com/ductone/protoc-gen-pgdb/pgdb/v1   4.693s
```

## Links

- **OPS-2314** (this fix)
- **protoc-gen-pgdb #139** — introduced the query-time `:*`
- **IGA-1440** — trailing-partial multi-dot recall that must be preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
