### PR TITLE
feat(schema): retrofit storage_parameters onto existing partition children

### DIFF
--- a/example/models/food/v1/food_test.go
+++ b/example/models/food/v1/food_test.go
@@ -1173,3 +1173,88 @@ func TestKSUIDCollationV17(t *testing.T) {
 	require.Equal(t, testData[0].GetIngredientId(), ingredientIDs[0], "First KSUID should be earlier timestamp")
 	require.Equal(t, testData[1].GetIngredientId(), ingredientIDs[1], "Second KSUID should be later timestamp")
 }
+
+// storageParamAlters filters rendered migrations down to storage-parameter ALTERs.
+func storageParamAlters(lines []string) []string {
+	out := make([]string, 0)
+	for _, q := range lines {
+		if strings.HasPrefix(strings.TrimSpace(q), "ALTER TABLE") && strings.Contains(q, "SET (") {
+			out = append(out, q)
+		}
+	}
+	return out
+}
+
+// requireNoChildFillfactor is the negative of requireChildFillfactor: it asserts the
+// child carries no fillfactor at all, which is how a partition created before the
+// model declared storage parameters looks.
+func requireNoChildFillfactor(t *testing.T, pg *pgtest.PG, child string) {
+	t.Helper()
+	var fillfactor *string
+	err := pg.DB.QueryRow(context.Background(), `SELECT (
+			SELECT option_value FROM pg_options_to_table(c.reloptions)
+			WHERE option_name = 'fillfactor'
+		)
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = 'public' AND c.relname = $1;`, child).Scan(&fillfactor)
+	require.NoErrorf(t, err, "reading reloptions for partition %s", child)
+	require.Nilf(t, fillfactor, "partition %s should have no fillfactor yet", child)
+}
+
+// TestPartitionChildStorageParamRetrofit covers the retrofit path. Tenant partitions
+// never roll over, so a child that already existed when the model gained
+// storage_parameters would otherwise keep the default forever.
+func TestPartitionChildStorageParamRetrofit(t *testing.T) {
+	ctx := context.Background()
+	pg, err := pgtest.Start()
+	require.NoError(t, err)
+	defer pg.Stop()
+
+	_, err = pg.DB.Exec(ctx, "CREATE EXTENSION IF NOT EXISTS btree_gin; CREATE EXTENSION IF NOT EXISTS vector;")
+	require.NoError(t, err)
+
+	// Pasta is tenant-list partitioned and declares fillfactor: 90.
+	msg := Pasta_builder{TenantId: "t1", Id: "p1"}.Build()
+	tableName := msg.DBReflect(pgdb_v1.DialectV13).Descriptor().TableName()
+
+	schema, err := pgdb_v1.CreateSchema(msg, pgdb_v1.DialectV13)
+	require.NoError(t, err)
+	for _, q := range schema {
+		_, err = pg.DB.Exec(ctx, q)
+		require.NoErrorf(t, err, "failed to execute: %s", q)
+	}
+
+	fakeTenantIds := []string{"t1", "t2", "t3"}
+	testCreatePartitionTables(t, pg, msg, fakeTenantIds)
+	childTables := verifySubTables(t, pg, tableName, fakeTenantIds)
+	require.NotEmpty(t, childTables)
+
+	// Children created after the declaration already carry it, so nothing is pending.
+	lines, err := pgdb_v1.Migrations(ctx, pg.DB, msg, pgdb_v1.DialectV13)
+	require.NoError(t, err)
+	require.Empty(t, storageParamAlters(lines), "converged children should emit no ALTER")
+
+	// Simulate a child that predates the declaration.
+	stale := childTables[0]
+	_, err = pg.DB.Exec(ctx, fmt.Sprintf("ALTER TABLE %s RESET (fillfactor)", stale))
+	require.NoError(t, err)
+	requireNoChildFillfactor(t, pg, stale)
+
+	lines, err = pgdb_v1.Migrations(ctx, pg.DB, msg, pgdb_v1.DialectV13)
+	require.NoError(t, err)
+	alters := storageParamAlters(lines)
+	require.Len(t, alters, 1, "only the stale child should be retrofitted")
+	require.Contains(t, alters[0], stale)
+
+	for _, q := range alters {
+		_, err = pg.DB.Exec(ctx, q)
+		require.NoErrorf(t, err, "failed to execute: %s", q)
+	}
+	requireChildFillfactor(t, pg, []string{stale}, "90")
+
+	// And no churn once every child is correct again.
+	lines, err = pgdb_v1.Migrations(ctx, pg.DB, msg, pgdb_v1.DialectV13)
+	require.NoError(t, err)
+	require.Empty(t, storageParamAlters(lines), "no ALTER once children are correct")
+}

--- a/pgdb/v1/schema.go
+++ b/pgdb/v1/schema.go
@@ -290,16 +290,103 @@ func readStorageParameters(ctx context.Context, db sqlScanner, desc Descriptor) 
 		return storageParams, nil
 	}
 
-	// Parse reloptions array: {"autovacuum_vacuum_threshold=10000", "fillfactor=80"}
-	// Each element is in the format "key=value"
+	parseReloptions(reloptions, storageParams)
+
+	return storageParams, nil
+}
+
+// parseReloptions fills dst from a pg_class.reloptions array whose elements are
+// "key=value".
+func parseReloptions(reloptions []string, dst map[string]string) {
 	for _, opt := range reloptions {
 		parts := strings.SplitN(opt, "=", 2)
 		if len(parts) == 2 {
-			storageParams[parts[0]] = parts[1]
+			dst[parts[0]] = parts[1]
 		}
 	}
+}
 
-	return storageParams, nil
+// maxPartitionChildStorageParamAlters bounds how many child ALTERs one Migrations
+// call emits. Each takes a brief ACCESS EXCLUSIVE lock, and the consumer abandons
+// a table's remaining statements on the first lock_timeout, so an unbounded batch
+// on a many-tenant table could stall convergence behind one busy partition.
+// Children are ordered by name and only emitted when they actually differ, so
+// successive runs advance through the set.
+const maxPartitionChildStorageParamAlters = 50
+
+// partitionChildParams is one partition child's current reloptions. Ordered
+// rather than mapped so the per-run cap advances deterministically.
+type partitionChildParams struct {
+	tableName string
+	params    map[string]string
+}
+
+// partitionChildAlters renders at most limit ALTERs, one per child whose reloptions
+// differ from what desc declares. Children already in agreement render nothing, so
+// each run advances through the set rather than re-emitting the same prefix.
+func partitionChildAlters(desc Descriptor, children []partitionChildParams, limit int) []string {
+	alters := make([]string, 0)
+	for _, child := range children {
+		if len(alters) >= limit {
+			break
+		}
+		if alter := storageParams2alterTable(desc, child.tableName, child.params); alter != "" {
+			alters = append(alters, alter)
+		}
+	}
+	return alters
+}
+
+// readPartitionChildStorageParameters returns the current reloptions of every
+// partition child of desc's table, ordered by child relation name.
+func readPartitionChildStorageParameters(ctx context.Context, db sqlScanner, desc Descriptor) ([]partitionChildParams, error) {
+	dialect := goqu.Dialect("postgres")
+
+	/*
+		SELECT child.relname, child.reloptions
+		FROM pg_inherits
+		JOIN pg_class parent ON parent.oid = pg_inherits.inhparent
+		JOIN pg_class child ON child.oid = pg_inherits.inhrelid
+		JOIN pg_namespace ON pg_namespace.oid = child.relnamespace
+		WHERE parent.relname = 'table_name' AND pg_namespace.nspname = 'public'
+		ORDER BY child.relname;
+	*/
+	qb := dialect.From("pg_inherits")
+	qb = qb.Select("child.relname", "child.reloptions")
+	qb = qb.Join(goqu.T("pg_class").As("parent"), goqu.On(goqu.I("parent.oid").Eq(goqu.I("pg_inherits.inhparent"))))
+	qb = qb.Join(goqu.T("pg_class").As("child"), goqu.On(goqu.I("child.oid").Eq(goqu.I("pg_inherits.inhrelid"))))
+	qb = qb.Join(goqu.T("pg_namespace"), goqu.On(goqu.I("pg_namespace.oid").Eq(goqu.I("child.relnamespace"))))
+	qb = qb.Where(goqu.L("parent.relname = ?", desc.TableName()))
+	qb = qb.Where(goqu.L("pg_namespace.nspname = ?", "public"))
+	qb = qb.Order(goqu.I("child.relname").Asc())
+	query, params, err := qb.ToSQL()
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := db.Query(ctx, query, params...)
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	children := make([]partitionChildParams, 0)
+	for rows.Next() {
+		var childName string
+		var reloptions []string
+		if err := rows.Scan(&childName, &reloptions); err != nil {
+			return nil, err
+		}
+		childParams := make(map[string]string)
+		parseReloptions(reloptions, childParams)
+		children = append(children, partitionChildParams{tableName: childName, params: childParams})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return children, nil
 }
 
 func tableIsParentPartition(ctx context.Context, db sqlScanner, tableName string) (bool, error) {
@@ -412,6 +499,18 @@ func Migrations(ctx context.Context, db sqlScanner, msg DBReflectMessage, dialec
 		if storageParamsAlter := storageParams2alter(desc, existingStorageParams); storageParamsAlter != "" {
 			rv = append(rv, storageParamsAlter)
 		}
+	}
+
+	// A partitioned parent cannot carry storage parameters itself, so its children
+	// are reconciled individually. Emitted last on purpose: the consumer abandons a
+	// table's remaining statements on the first lock_timeout, and a contended child
+	// must not cost us the column and index statements above.
+	if isPartitionedParent(desc) && desc.GetStorageParameters() != nil {
+		children, err := readPartitionChildStorageParameters(ctx, db, desc)
+		if err != nil {
+			return nil, err
+		}
+		rv = append(rv, partitionChildAlters(desc, children, maxPartitionChildStorageParamAlters)...)
 	}
 
 	return rv, nil

--- a/pgdb/v1/schema_sql.go
+++ b/pgdb/v1/schema_sql.go
@@ -208,6 +208,13 @@ func partitionStorageParams(desc Descriptor) string {
 }
 
 func storageParams2alter(desc Descriptor, existingParams map[string]string) string {
+	return storageParams2alterTable(desc, desc.TableName(), existingParams)
+}
+
+// storageParams2alterTable diffs desc's declared storage parameters against
+// existingParams and renders the ALTER for tableName. Partition children need the
+// same diff applied to a relation the descriptor does not name.
+func storageParams2alterTable(desc Descriptor, tableName string, existingParams map[string]string) string {
 	sp := desc.GetStorageParameters()
 	if sp == nil {
 		return ""
@@ -338,7 +345,7 @@ func storageParams2alter(desc Descriptor, existingParams map[string]string) stri
 
 	buf := &bytes.Buffer{}
 	_, _ = buf.WriteString("ALTER TABLE ")
-	pgWriteString(buf, desc.TableName())
+	pgWriteString(buf, tableName)
 	_, _ = buf.WriteString("\nSET (\n  ")
 	_, _ = buf.WriteString(strings.Join(params, ",\n  "))
 	_, _ = buf.WriteString("\n)\n")

--- a/pgdb/v1/schema_sql_test.go
+++ b/pgdb/v1/schema_sql_test.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -465,6 +466,72 @@ func TestPartitionStorageParamsClauseOrder(t *testing.T) {
 	if !strings.HasSuffix(stmt, ");") {
 		t.Errorf("statement must end with );, got:\n%s", stmt)
 	}
+}
+
+func TestPartitionChildAlters(t *testing.T) {
+	sp := &MessageOptions_StorageParameters{}
+	sp.SetFillfactor(90)
+	desc := &mockDescriptorWithStorageParams{
+		mockDescriptor: mockDescriptor{tableName: "parent"},
+		storageParams:  sp,
+	}
+
+	drifted := func(n int) []partitionChildParams {
+		out := make([]partitionChildParams, 0, n)
+		for i := 0; i < n; i++ {
+			out = append(out, partitionChildParams{
+				tableName: fmt.Sprintf("parent_%03d", i),
+				params:    map[string]string{},
+			})
+		}
+		return out
+	}
+
+	t.Run("children already correct emit nothing", func(t *testing.T) {
+		converged := []partitionChildParams{
+			{tableName: "parent_000", params: map[string]string{"fillfactor": "90"}},
+			{tableName: "parent_001", params: map[string]string{"fillfactor": "90"}},
+		}
+		if got := partitionChildAlters(desc, converged, 50); len(got) != 0 {
+			t.Errorf("Expected no ALTERs for converged children, got %d:\n%v", len(got), got)
+		}
+	})
+
+	t.Run("under the limit emits one per drifted child", func(t *testing.T) {
+		alters := partitionChildAlters(desc, drifted(3), 50)
+		if len(alters) != 3 {
+			t.Fatalf("Expected 3 ALTERs, got %d", len(alters))
+		}
+		for i, alter := range alters {
+			want := fmt.Sprintf("parent_%03d", i)
+			if !strings.Contains(alter, want) {
+				t.Errorf("ALTER %d should target %s, got:\n%s", i, want, alter)
+			}
+			if !strings.Contains(alter, "fillfactor = 90") {
+				t.Errorf("ALTER %d should set fillfactor = 90, got:\n%s", i, alter)
+			}
+		}
+	})
+
+	t.Run("over the limit truncates in order", func(t *testing.T) {
+		alters := partitionChildAlters(desc, drifted(120), 50)
+		if len(alters) != 50 {
+			t.Fatalf("A single run must stay bounded at 50, got %d", len(alters))
+		}
+		if !strings.Contains(alters[0], "parent_000") {
+			t.Errorf("First ALTER should target parent_000, got:\n%s", alters[0])
+		}
+		if !strings.Contains(alters[49], "parent_049") {
+			t.Errorf("Last ALTER should target parent_049, got:\n%s", alters[49])
+		}
+	})
+
+	t.Run("no storage parameters declared emits nothing", func(t *testing.T) {
+		bare := &mockDescriptor{tableName: "parent"}
+		if got := partitionChildAlters(bare, drifted(5), 50); len(got) != 0 {
+			t.Errorf("Expected no ALTERs when nothing is declared, got %d", len(got))
+		}
+	})
 }
 
 func TestStorageParams2alter(t *testing.T) {


### PR DESCRIPTION
## What was broken

PR #159 (v0.12.2) made `storage_parameters` reach partition children at **creation
time**. Nothing retrofitted children that already existed.

Which strategy that actually mattered for:

- **Tenant-list partitions (`partitioned = true`) — the real problem.** They never
  roll over. A child created before the model declared the option keeps the default
  forever, silently.
- KSUID and date partitions self-heal: retention rolls old children out and new ones
  are created with the declared `WITH (...)`.

## The change

At the end of `Migrations()`:

```go
if isPartitionedParent(desc) && desc.GetStorageParameters() != nil {
    children, err := readPartitionChildStorageParameters(ctx, db, desc)
    ...
    rv = append(rv, partitionChildAlters(desc, children, maxPartitionChildStorageParamAlters)...)
}
```

Three deliberate properties:

1. **Emitted last.** The consumer (c1 `pkg/postgres/xpgdb/schema.go`) breaks out of a
   table's statement loop on the first `55P03` lock_timeout. Putting child ALTERs last
   means a contended tenant partition can only cost *other child ALTERs* — never the
   column-adds and index statements ahead of them.
2. **Capped at 50 per run (`maxPartitionChildStorageParamAlters`), ordered by child
   name.** Bounds lock churn on a many-tenant table — each `ALTER TABLE ... SET (...)`
   takes a brief ACCESS EXCLUSIVE lock. Self-advancing: converged children render
   nothing, so the next run's first 50 are the next 50 that actually drift.
3. **Diff-driven.** Reuses the existing per-key diff via a new
   `storageParams2alterTable(desc, tableName, existingParams)`; `storageParams2alter`
   is now a one-line wrapper, so `TestStorageParams2alter` is unchanged and still
   passes. No blanket re-SET, no churn on already-correct children.

Also folds the duplicated `reloptions` `key=value` parsing into a shared
`parseReloptions` used by both the parent and the new child reader. The new
`pg_inherits` reader mirrors the existing `readStorageParameters` shape (same goqu
parameterization, same `nspname = 'public'` scoping).

Only costs an extra catalog query when the model is a partitioned parent *and*
declares storage parameters. `Migrations` still early-returns `CreateSchema` when the
table does not exist, so the retrofit block never runs on a fresh table.

## Tests

`pgdb/v1/schema_sql_test.go` — `TestPartitionChildAlters`: 120 drifted children
truncate to exactly 50 in name order (first is `parent_000`, last `parent_049`); a
converged set emits nothing; a descriptor with no declaration emits nothing.

`example/models/food/v1/food_test.go` — `TestPartitionChildStorageParamRetrofit`
simulates the real case end to end against a live Postgres: create the tenant-list
partitioned `Pasta` table (declares `fillfactor: 90`) plus three tenant children,
assert `Migrations` emits nothing while they are converged, then
`ALTER TABLE <child> RESET (fillfactor)` on one of the three to look like a
pre-declaration child. Asserts exactly *that* child is retrofitted, applies the ALTER,
verifies `fillfactor = 90` landed, and asserts a third `Migrations` call emits nothing.

**Negative test confirmed:** with the retrofit block disabled,
`TestPartitionChildStorageParamRetrofit` fails with `"[]" should have 1 item(s), but
has 0 / only the stale child should be retrofitted`. The test genuinely guards the
behaviour rather than passing vacuously.

## Residual limitation

`execReconcile` in the consumer notes that a `55P03` skip is "not self-healing
in-process" — it retries only on the next `EnsureSchema`, i.e. a redeploy. So a large
retrofit converges *across* deploys rather than within one: at 50/run, a 5,000-tenant
table needs ~100 deploys. Related: because the consumer abandons the remainder of a
table's statements on the first lock_timeout, a perpetually contended child head-of-line
blocks the children after it in name order for that run. Both are inherent to the
consumer's break-on-lock_timeout semantics, and both are strictly better than the status
quo, where nothing converged at all. `maxPartitionChildStorageParamAlters` is the knob
if the deploy count ever matters.

Linear: [IGA-3716](https://linear.app/ductone/issue/IGA-3716)

Note: the ticket's "route lock behaviour through reconcileLockTimeout / 55P03"
criterion required no code here — that machinery lives in the consumer, not this
library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
