### PR TITLE
test(schema): fail when the child reloptions assertion stops running

### DIFF
--- a/example/models/food/v1/food_test.go
+++ b/example/models/food/v1/food_test.go
@@ -112,6 +112,8 @@ func TestSchemaFoodPasta(t *testing.T) {
 		},
 	}
 
+	childFillfactorAsserted := 0
+
 	for _, testobj := range testobjects {
 		smsg := testobj.objects[0]
 		schema, err := pgdb_v1.CreateSchema(smsg, pgdb_v1.DialectV13)
@@ -203,12 +205,20 @@ func TestSchemaFoodPasta(t *testing.T) {
 			childTables := verifySubTables(t, pg, protoTableName, fakeTenantIds)
 			if sp := smsg.DBReflect(pgdb_v1.DialectV13).Descriptor().GetStorageParameters(); sp != nil && sp.HasFillfactor() {
 				requireChildFillfactor(t, pg, childTables, fmt.Sprintf("%d", sp.GetFillfactor()))
+				childFillfactorAsserted++
 			}
 			// Insert data into master table
 			testInsertAndVerify(t, pg, protoTableName, fakeTenantIds, testobj.objects)
 		}
 	}
 
+	// Only models declaring a fillfactor are checked above, so a dropped declaration
+	// would make that assertion vanish rather than fail. This is the only test
+	// covering the tenant-list path, which is in turn the only coverage of the
+	// Migrations suppression that keeps ALTER off a partitioned parent (SQLSTATE
+	// 42809), so the assertion going quiet must itself be a failure.
+	require.Positive(t, childFillfactorAsserted,
+		"no partitioned model declared a fillfactor; the child reloptions assertion stopped running")
 }
 
 func testCreatePartitionTables(t *testing.T, pg *pgtest.PG, msg pgdb_v1.DBReflectMessage, fakeTenantIds []string) {


### PR DESCRIPTION
`TestSchemaFoodPasta` loops over several partitioned models but only asserts child `fillfactor` for those that declare one:

```go
if sp := ...GetStorageParameters(); sp != nil && sp.HasFillfactor() {
    requireChildFillfactor(t, pg, childTables, fmt.Sprintf("%d", sp.GetFillfactor()))
}
```

The guard is necessary — only `Pasta` declares it. The cost is that removing that declaration would make the assertion silently disappear instead of failing.

That matters more than it looks. `Pasta` is the only tenant-list-partitioned example model, so this is the only test covering the tenant-list path — which is in turn the only coverage of the `Migrations` suppression that keeps `ALTER TABLE … SET (...)` off a partitioned parent (`SQLSTATE 42809`). Lose the assertion quietly and that suppression becomes untested.

## Change

Count the assertions that actually run and require at least one after the loop:

```go
require.Positive(t, childFillfactorAsserted,
    "no partitioned model declared a fillfactor; the child reloptions assertion stopped running")
```

A counter rather than a restructure or a rename, to keep the diff narrow.

## Verification

Simulating a dropped declaration fails with `"0" is not positive … the child reloptions assertion stopped running`, so the guard genuinely fires rather than merely passing alongside the existing assertions.

`./example/...` and `./...` both green; `gofmt` clean.

## Not in this PR

IGA-3723 also covers making CI lint the `example/` module, which stays open. It is not a one-line config change: `example/go.mod` needs a local `replace` to consume the in-repo library, which `gomoddirectives` flags, so enabling lint there requires a deliberate carve-out plus a ~26-finding cleanup (15 revive var-naming, 7 whitespace, 2 godot, 1 gosec, 1 forbidigo).

Linear: https://linear.app/ductone/issue/IGA-3723

🤖 Generated with [Claude Code](https://claude.com/claude-code)